### PR TITLE
Add quizzes and item status

### DIFF
--- a/backend/src/models/IModule.ts
+++ b/backend/src/models/IModule.ts
@@ -16,11 +16,18 @@ content:   string;
 
 links:     ILink[];
 images:    IImage[];
-videos:    string[];
-profiles:  string[];
-enabled:   boolean;
+  videos:    string[];
+  profiles:  string[];
+  enabled:   boolean;
 
-children?: IItem[];
+  quiz?: {
+    enabled: boolean;
+    question: string;
+    options: string[];
+    correct: number[]; // index(es) des bonnes réponses
+  };
+
+  children?: IItem[];
 }
 
 export interface IModule {

--- a/backend/src/models/IProgress.ts
+++ b/backend/src/models/IProgress.ts
@@ -1,5 +1,6 @@
 export interface IProgress {
-        username: string;           // identifiant CAF
-        moduleId: string;
-        visited:  string[];         // IDs d’items
-    }
+  username: string;           // identifiant CAF
+  moduleId: string;
+  visited:  string[];         // IDs d’items validés
+  status?: Record<string, string>; // itemId -> statut détaillé
+}

--- a/backend/src/routes/progress.ts
+++ b/backend/src/routes/progress.ts
@@ -12,16 +12,19 @@
                res.json(rows);
              });
       
-             /* PATCH /api/progress   body:{ username,moduleId,visited } – MAJ 1 module */
+             /* PATCH /api/progress   body:{ username,moduleId,visited,status } – MAJ 1 module */
              router.patch('/', (req, res) => {
-               const { username, moduleId, visited } = req.body as IProgress;
+               const { username, moduleId, visited, status } = req.body as IProgress;
                if (!username || !moduleId) return res.status(400).json({error:'Données manquantes'});
       
                const list = read<IProgress>(TABLE);
                const idx  = list.findIndex(p => p.username===username && p.moduleId===moduleId);
       
-               if (idx === -1) list.push({ username, moduleId, visited });
-               else            list[idx].visited = visited;
+               if (idx === -1) list.push({ username, moduleId, visited: visited ?? [], status: status ?? {} });
+               else {
+                 if (visited) list[idx].visited = visited;
+                 if (status)  list[idx].status  = status;
+               }
       
                write(TABLE, list);
                res.json({ ok:true });

--- a/client/src/api/modules.ts
+++ b/client/src/api/modules.ts
@@ -25,6 +25,13 @@ export interface IItem  {
   videos:    string[];
   profiles:  string[];
   enabled:   boolean;
+
+  quiz?: {
+    enabled: boolean;
+    question: string;
+    options: string[];
+    correct: number[];
+  };
       
   children?: IItem[];
 }
@@ -40,6 +47,7 @@ export interface IProgress {
   username: string;          // CAF
   moduleId: string;
   visited:  string[];        // ids d’items complétés
+  status?: Record<string,string>; // itemId -> statut
 }
       
       


### PR DESCRIPTION
## Summary
- add quiz fields to item model
- keep status per item in progress model
- support status updates and manager notifications
- offer advanced editor toggle or raw HTML in module editor
- handle quizzes and statuses in module page

## Testing
- `npm test --workspace client`
- `npm test --workspace backend` *(fails: Missing script)*