### PR TITLE
Add quiz support for module items

### DIFF
--- a/backend/src/data/modules.json
+++ b/backend/src/data/modules.json
@@ -23,6 +23,10 @@
           "Montoir"
         ],
         "enabled": true,
+        "quiz": {
+          "enabled": false,
+          "questions": []
+        },
         "children": [
           {
             "id": "823615c7-a15f-464f-bd9c-369efe9e5660",
@@ -43,6 +47,10 @@
               "Montoir"
             ],
             "enabled": true,
+            "quiz": {
+              "enabled": false,
+              "questions": []
+            },
             "children": []
           },
           {
@@ -67,6 +75,10 @@
               "Montoir"
             ],
             "enabled": true,
+            "quiz": {
+              "enabled": false,
+              "questions": []
+            },
             "children": []
           },
           {
@@ -91,6 +103,10 @@
               "Montoir"
             ],
             "enabled": true,
+            "quiz": {
+              "enabled": false,
+              "questions": []
+            },
             "children": []
           },
           {
@@ -117,6 +133,10 @@
               "Montoir"
             ],
             "enabled": true,
+            "quiz": {
+              "enabled": false,
+              "questions": []
+            },
             "children": []
           }
         ]
@@ -145,6 +165,10 @@
           "Montoir"
         ],
         "enabled": true,
+        "quiz": {
+          "enabled": false,
+          "questions": []
+        },
         "children": [
           {
             "id": "ffe016dd-3970-45b1-a898-3e3651461058",
@@ -159,6 +183,10 @@
               "Montoir"
             ],
             "enabled": true,
+            "quiz": {
+              "enabled": false,
+              "questions": []
+            },
             "children": []
           },
           {
@@ -174,6 +202,10 @@
               "Montoir"
             ],
             "enabled": true,
+            "quiz": {
+              "enabled": false,
+              "questions": []
+            },
             "children": []
           },
           {
@@ -195,6 +227,10 @@
               "Montoir"
             ],
             "enabled": true,
+            "quiz": {
+              "enabled": false,
+              "questions": []
+            },
             "children": []
           }
         ]
@@ -227,6 +263,10 @@
           "Montoir"
         ],
         "enabled": true,
+        "quiz": {
+          "enabled": false,
+          "questions": []
+        },
         "children": [
           {
             "id": "412c45d2-63ba-48d3-a79a-b5681ba72604",
@@ -255,6 +295,10 @@
               "Nantes"
             ],
             "enabled": true,
+            "quiz": {
+              "enabled": false,
+              "questions": []
+            },
             "children": []
           },
           {
@@ -284,6 +328,10 @@
               "Montoir"
             ],
             "enabled": true,
+            "quiz": {
+              "enabled": false,
+              "questions": []
+            },
             "children": []
           },
           {
@@ -313,6 +361,10 @@
               "Nantes"
             ],
             "enabled": true,
+            "quiz": {
+              "enabled": false,
+              "questions": []
+            },
             "children": []
           },
           {
@@ -327,6 +379,10 @@
               "Montoir"
             ],
             "enabled": true,
+            "quiz": {
+              "enabled": false,
+              "questions": []
+            },
             "children": []
           }
         ]
@@ -355,6 +411,10 @@
           "Nantes"
         ],
         "enabled": true,
+        "quiz": {
+          "enabled": false,
+          "questions": []
+        },
         "children": []
       },
       {
@@ -380,6 +440,10 @@
           "Nantes"
         ],
         "enabled": true,
+        "quiz": {
+          "enabled": false,
+          "questions": []
+        },
         "children": []
       },
       {
@@ -417,6 +481,10 @@
           "Montoir"
         ],
         "enabled": true,
+        "quiz": {
+          "enabled": false,
+          "questions": []
+        },
         "children": []
       },
       {
@@ -438,6 +506,10 @@
           "Montoir"
         ],
         "enabled": true,
+        "quiz": {
+          "enabled": false,
+          "questions": []
+        },
         "children": [
           {
             "id": "0ef78fbe-7242-47c1-80e9-5399492ca837",
@@ -458,6 +530,10 @@
               "Montoir"
             ],
             "enabled": true,
+            "quiz": {
+              "enabled": false,
+              "questions": []
+            },
             "children": []
           },
           {
@@ -476,6 +552,10 @@
             "videos": [],
             "profiles": [],
             "enabled": true,
+            "quiz": {
+              "enabled": false,
+              "questions": []
+            },
             "children": []
           },
           {
@@ -494,6 +574,10 @@
             "videos": [],
             "profiles": [],
             "enabled": true,
+            "quiz": {
+              "enabled": false,
+              "questions": []
+            },
             "children": []
           },
           {
@@ -512,6 +596,21 @@
             "videos": [],
             "profiles": [],
             "enabled": true,
+            "quiz": {
+              "enabled": true,
+              "questions": [
+                {
+                  "question": "ee",
+                  "options": [
+                    "e",
+                    "z"
+                  ],
+                  "correct": [
+                    1
+                  ]
+                }
+              ]
+            },
             "children": []
           }
         ]
@@ -529,6 +628,31 @@
           "Nantes"
         ],
         "enabled": true,
+        "quiz": {
+          "enabled": false,
+          "questions": [
+            {
+              "question": "\"\"\"\"",
+              "options": [
+                "es",
+                "ui"
+              ],
+              "correct": [
+                1
+              ]
+            },
+            {
+              "question": "a",
+              "options": [
+                "dez",
+                "ui"
+              ],
+              "correct": [
+                0
+              ]
+            }
+          ]
+        },
         "children": []
       }
     ],

--- a/backend/src/data/progress.json
+++ b/backend/src/data/progress.json
@@ -3,7 +3,8 @@
     "username": "logan",
     "moduleId": "module-1",
     "visited": [
-      "item-1"
+      "823615c7-a15f-464f-bd9c-369efe9e5660",
+      "601a451a-7e40-4004-b7d9-4d32baca0031"
     ]
   },
   {

--- a/backend/src/models/IModule.ts
+++ b/backend/src/models/IModule.ts
@@ -8,6 +8,17 @@ width?: number;
 align?: 'left' | 'center' | 'right';
 }
 
+export interface IQuizQuestion {
+  question: string;
+  options: string[];
+  correct: number[]; // indexes of good answers
+}
+
+export interface IQuiz {
+  enabled: boolean;
+  questions: IQuizQuestion[];
+}
+
 export interface IItem  {
 id:        string;
 title:     string;
@@ -17,10 +28,12 @@ content:   string;
 links:     ILink[];
 images:    IImage[];
 videos:    string[];
-profiles:  string[];
-enabled:   boolean;
+  profiles:  string[];
+  enabled:   boolean;
 
-children?: IItem[];
+  quiz?: IQuiz;
+
+  children?: IItem[];
 }
 
 export interface IModule {

--- a/client/src/api/modules.ts
+++ b/client/src/api/modules.ts
@@ -13,7 +13,18 @@ export interface IImage {
   width?: number;         // %  (10 – 100)
   align?: 'left' | 'center' | 'right';
 }
-      
+
+export interface IQuizQuestion {
+  question: string;
+  options: string[];
+  correct: number[];
+}
+
+export interface IQuiz {
+  enabled: boolean;
+  questions: IQuizQuestion[];
+}
+
 export interface IItem  {
   id:        string;
   title:     string;
@@ -25,7 +36,9 @@ export interface IItem  {
   videos:    string[];
   profiles:  string[];
   enabled:   boolean;
-      
+
+  quiz?: IQuiz;
+
   children?: IItem[];
 }
       

--- a/client/src/components/ItemContent.tsx
+++ b/client/src/components/ItemContent.tsx
@@ -1,10 +1,11 @@
              /* client/src/components/ItemContent.tsx
                 ───────────────────────────────────── */
       
-                import React from 'react';
-                import FavoriteButton from './FavoriteButton';
-                import './ItemContent.css';
-                import { IImage, ILink } from '../api/modules';
+import React from 'react';
+import FavoriteButton from './FavoriteButton';
+import Quiz from './Quiz';
+import './ItemContent.css';
+import { IImage, ILink, IQuiz } from '../api/modules';
       
 export interface ItemContentProps {
   /* ─── contenu ─── */
@@ -14,6 +15,10 @@ export interface ItemContentProps {
   links?:      ILink[];
   images?:     (string | IImage)[];
   videos?:     string[];
+
+  quiz?:       IQuiz;
+  quizPassed?: boolean;
+  onQuizPassed?: () => void;
       
                   /* ─── progression ─── */
                   isVisited:        boolean;
@@ -29,6 +34,7 @@ export interface ItemContentProps {
                 export default function ItemContent(props: ItemContentProps) {
   const {
     title, subtitle, description, links = [], images, videos,
+    quiz, quizPassed, onQuizPassed,
     isVisited, onToggleVisited,
     isFav,     onToggleFav,
   } = props;
@@ -109,6 +115,10 @@ export interface ItemContentProps {
                           ))}
                         </div>
                       ) : null}
+
+                      {quiz && quiz.enabled && (
+                        <Quiz quiz={quiz} onSuccess={onQuizPassed ?? (()=>{})} passed={quizPassed ?? false} />
+                      )}
                     </div>
                   );
                 }

--- a/client/src/components/Quiz.css
+++ b/client/src/components/Quiz.css
@@ -1,0 +1,45 @@
+.quiz {
+  border: 1px solid #ddd;
+  padding: 16px;
+  border-radius: 8px;
+  margin-top: 16px;
+  animation: fadeIn 0.3s ease;
+}
+.quiz-question { margin-bottom: 12px; }
+.quiz-option { display: block; margin: 4px 0; }
+.quiz-submit {
+  background: #008bd2;
+  color: #fff;
+  border: none;
+  padding: 6px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.quiz-submit:hover { background: #006fa1; }
+.quiz-result { font-weight: bold; margin-top: 8px; }
+.quiz-popup {
+  background: rgba(0,0,0,0.6);
+  position: fixed;
+  top:0;left:0;right:0;bottom:0;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  animation: fadeIn 0.2s ease;
+}
+.quiz-popup p {
+  background:#fff;
+  padding:20px 30px;
+  border-radius:8px 8px 0 0;
+  margin:0;
+}
+.quiz-popup button {
+  background:#fff;
+  border:none;
+  padding:8px 16px;
+  border-radius:0 0 8px 8px;
+  cursor:pointer;
+}
+@keyframes fadeIn {
+  from { opacity:0; }
+  to   { opacity:1; }
+}

--- a/client/src/components/Quiz.tsx
+++ b/client/src/components/Quiz.tsx
@@ -1,0 +1,76 @@
+import React, { useState } from 'react';
+import { IQuiz } from '../api/modules';
+import './Quiz.css';
+
+interface Props {
+  quiz: IQuiz;
+  onSuccess: () => void;
+  passed: boolean;
+}
+
+export default function Quiz({ quiz, onSuccess, passed }: Props) {
+  const [answers, setAnswers] = useState<number[][]>(
+    quiz.questions.map(() => [])
+  );
+  const [result, setResult] = useState<'ok' | 'fail' | null>(null);
+
+  const toggle = (qi: number, opt: number, checked: boolean) => {
+    setAnswers(prev => {
+      const arr = prev.map(a => [...a]);
+      const set = new Set(arr[qi]);
+      checked ? set.add(opt) : set.delete(opt);
+      arr[qi] = Array.from(set);
+      return arr;
+    });
+  };
+
+  const submit = () => {
+    let good = 0;
+    quiz.questions.forEach((q, i) => {
+      const ans = [...answers[i]].sort().join(',');
+      const corr = [...q.correct].sort().join(',');
+      if (ans === corr) good++;
+    });
+    const score = (good / quiz.questions.length) * 100;
+    if (score >= 80) {
+      setResult('ok');
+      onSuccess();
+    } else {
+      setResult('fail');
+    }
+  };
+
+  return (
+    <div className="quiz">
+      <h3>Quiz</h3>
+      {quiz.questions.map((q, qi) => (
+        <div key={qi} className="quiz-question">
+          <p>{q.question}</p>
+          {q.options.map((o, oi) => (
+            <label key={oi} className="quiz-option">
+              <input
+                type="checkbox"
+                checked={answers[qi].includes(oi)}
+                onChange={e => toggle(qi, oi, e.target.checked)}
+                disabled={passed}
+              />{' '}
+              {o}
+            </label>
+          ))}
+        </div>
+      ))}
+      {result === 'ok' && <p className="quiz-result success">Bravo ! Quiz réussi.</p>}
+      {result === 'fail' && (
+        <div className="quiz-popup">
+          <p>Quiz échoué… réessayez !</p>
+          <button onClick={() => setResult(null)}>Fermer</button>
+        </div>
+      )}
+      {!passed && (
+        <button className="quiz-submit" onClick={submit}>
+          Valider le quiz
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- define quiz data structures for modules
- enable quiz editing in ModuleEditor
- display and validate quizzes for trainees
- block validation of items until quiz is passed

## Testing
- `npm --workspace backend run build`
- `npm --workspace client run build`
