### PR TITLE
Add multiple item states

### DIFF
--- a/backend/src/data/progress.json
+++ b/backend/src/data/progress.json
@@ -2,20 +2,20 @@
   {
     "username": "logan",
     "moduleId": "module-1",
-    "visited": [
-      "item-1"
-    ]
+    "states": {
+      "item-1": "finished"
+    }
   },
   {
     "username": "user",
     "moduleId": "module-1",
-    "visited": [
-      "item-1"
-    ]
+    "states": {
+      "item-1": "finished"
+    }
   },
   {
     "username": "logan",
     "moduleId": "1746639040310",
-    "visited": []
+    "states": {}
   }
 ]

--- a/backend/src/models/IProgress.ts
+++ b/backend/src/models/IProgress.ts
@@ -1,5 +1,13 @@
+export type ProgressState =
+  | 'not-started'
+  | 'in-progress'
+  | 'struggling'
+  | 'checking'
+  | 'validated'
+  | 'finished';
+
 export interface IProgress {
-        username: string;           // identifiant CAF
-        moduleId: string;
-        visited:  string[];         // IDs d’items
-    }
+  username: string;                 // identifiant CAF
+  moduleId: string;
+  states:   Record<string, ProgressState>; // état par item
+}

--- a/backend/src/routes/progress.ts
+++ b/backend/src/routes/progress.ts
@@ -1,6 +1,6 @@
              import { Router } from 'express';
              import { read, write } from '../config/dataStore';
-             import { IProgress }  from '../models/IProgress';
+import { IProgress, ProgressState }  from '../models/IProgress';
              import { IUser }      from '../models/IUser';
       
              const router = Router();
@@ -12,20 +12,32 @@
                res.json(rows);
              });
       
-             /* PATCH /api/progress   body:{ username,moduleId,visited } – MAJ 1 module */
-             router.patch('/', (req, res) => {
-               const { username, moduleId, visited } = req.body as IProgress;
-               if (!username || !moduleId) return res.status(400).json({error:'Données manquantes'});
-      
-               const list = read<IProgress>(TABLE);
-               const idx  = list.findIndex(p => p.username===username && p.moduleId===moduleId);
-      
-               if (idx === -1) list.push({ username, moduleId, visited });
-               else            list[idx].visited = visited;
-      
-               write(TABLE, list);
-               res.json({ ok:true });
-             });
+/* PATCH /api/progress   body:{ username,moduleId,itemId,state } */
+router.patch('/', (req, res) => {
+  const { username, moduleId, itemId, state } = req.body as {
+    username: string;
+    moduleId: string;
+    itemId:   string;
+    state:    ProgressState;
+  };
+
+  if (!username || !moduleId || !itemId || !state)
+    return res.status(400).json({ error: 'Données manquantes' });
+
+  const list = read<IProgress>(TABLE);
+  const idx  = list.findIndex(p => p.username===username && p.moduleId===moduleId);
+
+  if (idx === -1) {
+    list.push({ username, moduleId, states: { [itemId]: state } });
+  } else {
+    const cur = list[idx].states ?? {};
+    cur[itemId] = state;
+    list[idx].states = cur;
+  }
+
+  write(TABLE, list);
+  res.json({ ok:true });
+});
       
              /* GET /api/progress?managerId=… – progression de tous les CAF d’un manager */
              router.get('/', (req, res) => {

--- a/client/src/api/modules.ts
+++ b/client/src/api/modules.ts
@@ -23,6 +23,7 @@ export interface IItem  {
   links:     ILink[];
   images:    IImage[];    // ← anciennement string[]
   videos:    string[];
+  quiz?:     boolean;
   profiles:  string[];
   enabled:   boolean;
       

--- a/client/src/api/progress.ts
+++ b/client/src/api/progress.ts
@@ -1,0 +1,27 @@
+import axios from 'axios';
+
+export type ProgressState =
+  | 'not-started'
+  | 'in-progress'
+  | 'struggling'
+  | 'checking'
+  | 'validated'
+  | 'finished';
+
+export interface IProgress {
+  username: string;
+  moduleId: string;
+  states: Record<string, ProgressState>;
+}
+
+export const getProgress = async (username: string): Promise<IProgress[]> =>
+  (await axios.get(`/api/progress/${username}`)).data;
+
+export const updateItemState = async (
+  username: string,
+  moduleId: string,
+  itemId: string,
+  state: ProgressState,
+): Promise<void> => {
+  await axios.patch('/api/progress', { username, moduleId, itemId, state });
+};

--- a/client/src/components/ItemContent.tsx
+++ b/client/src/components/ItemContent.tsx
@@ -4,7 +4,8 @@
                 import React from 'react';
                 import FavoriteButton from './FavoriteButton';
                 import './ItemContent.css';
-                import { IImage, ILink } from '../api/modules';
+import { IImage, ILink } from '../api/modules';
+import { ProgressState } from '../api/progress';
       
 export interface ItemContentProps {
   /* ─── contenu ─── */
@@ -14,10 +15,11 @@ export interface ItemContentProps {
   links?:      ILink[];
   images?:     (string | IImage)[];
   videos?:     string[];
-      
-                  /* ─── progression ─── */
-                  isVisited:        boolean;
-                  onToggleVisited:  () => void;
+
+  /* ─── progression ─── */
+  state:          ProgressState;
+  onChangeState:  (st: ProgressState) => void;
+  hasQuiz?:       boolean;
       
                   /* ─── favoris ─── */
                   isFav:       boolean;
@@ -29,8 +31,8 @@ export interface ItemContentProps {
                 export default function ItemContent(props: ItemContentProps) {
   const {
     title, subtitle, description, links = [], images, videos,
-    isVisited, onToggleVisited,
-    isFav,     onToggleFav,
+    state, onChangeState, hasQuiz,
+    isFav, onToggleFav,
   } = props;
       
                   return (
@@ -43,15 +45,31 @@ export interface ItemContentProps {
         </div>
       
                         <div className="item-actions">
-                          {/* coche “vu” */}
-                          <button
-                            type="button"
-                            className="check-button"
-                            onClick={onToggleVisited}
-                            aria-label={isVisited ? 'Marquer non visité' : 'Marquer visité'}
-                          >
-                            {isVisited ? '✅' : '⭕'}
-                          </button>
+                          {/* état de progression */}
+                          {state === 'not-started' && (
+                            <button
+                              type="button"
+                              className="check-button"
+                              onClick={() => onChangeState('in-progress')}
+                            >
+                              ▶ Démarrer
+                            </button>
+                          )}
+                          {state !== 'not-started' && (
+                            <select
+                              value={state}
+                              onChange={e => onChangeState(e.target.value as any)}
+                            >
+                              <option value="not-started">⭕ Non commencé</option>
+                              <option value="in-progress">🚧 En cours</option>
+                              <option value="struggling">❗ En difficulté</option>
+                              <option value="checking">🔎 Vérification</option>
+                              {hasQuiz && (
+                                <option value="validated">✅ Validé</option>
+                              )}
+                              <option value="finished">🏁 Fini</option>
+                            </select>
+                          )}
       
                           {/* étoile favoris */}
                           <FavoriteButton isFav={isFav} onClick={onToggleFav} />
@@ -112,3 +130,4 @@ export interface ItemContentProps {
                     </div>
                   );
                 }
+

--- a/client/src/components/SidebarMenu.tsx
+++ b/client/src/components/SidebarMenu.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { IItem } from '../api/modules';
+import { ProgressState } from '../api/progress';
 import './SidebarMenu.css';
 
 /* ------------------------------------------------------------------ */
@@ -12,16 +13,16 @@ export interface SidebarMenuProps {
   selected: string;
   /** Callback lorsqu’on choisit un item */
   onSelect: (id: string) => void;
-  /** Liste des IDs déjà visités (pour griser / cocher) */
-  visited:  string[];
+  /** États des items */
+  states: Record<string, ProgressState>;
 }
 
 /* ------------------------------------------------------------------ */
 /*  Contexte interne : on évite de “passer” trois props à chaque       */
-/*  niveau récursif ; on stocke selected / onSelect / visited ici      */
+/*  niveau récursif ; on stocke selected / onSelect / states ici       */
 /* ------------------------------------------------------------------ */
 const CTX = React.createContext<
-  Pick<SidebarMenuProps, 'selected' | 'onSelect' | 'visited'> | null
+  Pick<SidebarMenuProps, 'selected' | 'onSelect' | 'states'> | null
 >(null);
 
 /* ------------------------------------------------------------------ */
@@ -29,14 +30,16 @@ const CTX = React.createContext<
 /* ------------------------------------------------------------------ */
 function Branch({ branch }: { branch: IItem[] }) {
   const ctx = React.useContext(CTX)!;        // le “!” car toujours défini ici
-  const { selected, onSelect, visited } = ctx;
+  const { selected, onSelect, states } = ctx;
 
   return (
     <ul className="sidebar">
       {branch.map((it) => {
+        const st = states[it.id];
+        const done = st === 'finished' || st === 'validated';
         const cls =
           `menu-item${it.id === selected ? ' active' : ''}` +
-          `${visited.includes(it.id) ? ' visited' : ''}`;
+          `${done ? ' visited' : ''}`;
 
         return (
           <li key={it.id} className={cls}>
@@ -59,10 +62,10 @@ function Branch({ branch }: { branch: IItem[] }) {
 /*  Composant principal exporté                                        */
 /* ------------------------------------------------------------------ */
 export default function SidebarMenu(props: SidebarMenuProps) {
-  const { items, selected, onSelect, visited } = props;
+  const { items, selected, onSelect, states } = props;
 
   return (
-    <CTX.Provider value={{ selected, onSelect, visited }}>
+    <CTX.Provider value={{ selected, onSelect, states }}>
       <nav>
         <Branch branch={items} />
       </nav>

--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -3,10 +3,11 @@
    import React, { useEffect, useState } from 'react';
    import { Link } from 'react-router-dom';
 
-   import ProgressBar        from '../components/ProgressBar';
-   import { getModules,
+import ProgressBar        from '../components/ProgressBar';
+import { getModules,
             IModule,
             IItem }          from '../api/modules';
+import { getProgress, IProgress } from '../api/progress';
    import { flatten }        from '../utils/items';
    import { useAuth }        from '../context/AuthContext';
    import './HomePage.css';
@@ -26,13 +27,14 @@
      const { user } = useAuth();           // ← on connaît le site du CAF
      const site = user?.site;              // « Nantes » | « Montoir » | undefined
 
-     const [modules, setModules] = useState<IModule[]>([]);
-     const [loading, setLoading] = useState(true);
-     const [error,   setError]   = useState('');
+    const [modules, setModules] = useState<IModule[]>([]);
+    const [progress, setProgress] = useState<IProgress[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error,   setError]   = useState('');
 
      /* charge la liste une seule fois */
-     useEffect(() => {
-       getModules()
+    useEffect(() => {
+      getModules()
          .then((mods) => {
            if (!Array.isArray(mods)) throw new Error('Réponse inattendue du serveur');
 
@@ -45,8 +47,13 @@
            setModules(filtered);
          })
          .catch((e) => setError(e.message ?? 'Erreur réseau'))
-         .finally(() => setLoading(false));
-     }, [site]);
+        .finally(() => setLoading(false));
+    }, [site]);
+
+    useEffect(() => {
+      if (!user) return;
+      getProgress(user.username).then(setProgress).catch(console.error);
+    }, [user]);
 
      /* états spéciaux */
      if (loading) return <p style={{ padding: '2rem' }}>Chargement…</p>;
@@ -59,11 +66,15 @@
        (n, m) => n + flatten(m.items).length,
        0,
      );
-     const totalVisited = modules.reduce((n, m) => {
-       const vis = JSON.parse(localStorage.getItem(`visited_${m.id}`) ?? '[]') as string[];
-       /* seuls les IDs encore présents comptent */
-       return n + vis.filter(id => flatten(m.items).some(it => it.id === id)).length;
-     }, 0);
+    const totalVisited = modules.reduce((n, m) => {
+      const row = progress.find(p => p.moduleId === m.id);
+      const st  = row?.states ?? {};
+      const done = flatten(m.items).filter(it => {
+        const s = st[it.id];
+        return s === 'finished' || s === 'validated';
+      }).length;
+      return n + done;
+    }, 0);
 
      /* rendu normal */
      return (
@@ -76,10 +87,14 @@
          </div>
 
          <div className="modules-grid">
-           {modules.map((m) => {
-             const flat = flatten(m.items);
-             const vis  = JSON.parse(localStorage.getItem(`visited_${m.id}`) ?? '[]') as string[];
-             const current = vis.filter(id => flat.some(it => it.id === id)).length;
+          {modules.map((m) => {
+            const flat = flatten(m.items);
+            const row  = progress.find(p => p.moduleId === m.id);
+            const st   = row?.states ?? {};
+            const current = flat.filter(it => {
+              const s = st[it.id];
+              return s === 'finished' || s === 'validated';
+            }).length;
 
              return (
                <div key={m.id} className="module-card">


### PR DESCRIPTION
## Summary
- expand progress model with multiple item states
- expose new progress API and adapt backend route
- persist progress state changes in backend
- update item, sidebar and pages to use new progress states

## Testing
- `npm --workspace backend run build`
- `CI=1 npm --workspace client test --silent -- --passWithNoTests`