### PR TITLE
Fix summary editor and confirm unsaved changes

### DIFF
--- a/client/src/pages/AdminModuleEditor.tsx
+++ b/client/src/pages/AdminModuleEditor.tsx
@@ -10,6 +10,7 @@ export default function AdminModuleEditor() {
   const { moduleId } = useParams<{ moduleId: string }>();
   const navigate = useNavigate();
   const [mod, setMod] = useState<IModule | null>(null);
+  const [dirty, setDirty] = useState(false);
 
   /* chargement */
   useEffect(() => {
@@ -60,10 +61,18 @@ export default function AdminModuleEditor() {
         style={{ position : 'sticky', justifyContent: 'space-between', padding: '8px 24px'}}
       >
         <h2>Admin › Modules › {mod.title || '(nouveau)'}</h2>
-        <button onClick={() => navigate('/admin/modules')}>← Retour modules</button>
+        <button
+          onClick={() => {
+            if (!dirty || window.confirm('Quitter sans sauvegarder ?')) {
+              navigate('/admin/modules');
+            }
+          }}
+        >
+          ← Retour modules
+        </button>
       </header>
 
-      <ModuleEditor module={mod} onChange={save} />
+      <ModuleEditor module={mod} onChange={save} onDirtyChange={setDirty} />
     </div>
   );
 }

--- a/client/src/pages/AdminModulesPage.tsx
+++ b/client/src/pages/AdminModulesPage.tsx
@@ -72,7 +72,10 @@ export default function AdminModulesPage() {
               </div>
             </div>
 
-            <p className="summary">{m.summary || '—'}</p>
+            <p
+              className="summary"
+              dangerouslySetInnerHTML={{ __html: m.summary || '—' }}
+            />
 
             <footer>
               <Link to={`${basePath}/modules/${m.id}`} className="btn-secondary">

--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -86,7 +86,12 @@
                  <h2 className="module-title">{m.title}</h2>
 
                  {/* résumé / description si présent */}
-                 {m.summary && <p className="summary">{m.summary}</p>}
+                 {m.summary && (
+                   <p
+                     className="summary"
+                     dangerouslySetInnerHTML={{ __html: m.summary }}
+                   />
+                 )}
 
                  {/* ───────── barre du module ───────── */}
                  <div className="module-progress.progress">


### PR DESCRIPTION
## Summary
- use `AdvancedEditor` for module summary
- block page unload and report dirty state
- show unsaved changes confirmation when returning
- render summary HTML on modules lists and homepage

## Testing
- `npm run build`