### PR TITLE
Add notifier service for notifications

### DIFF
--- a/backend/dist/index.js
+++ b/backend/dist/index.js
@@ -14,6 +14,7 @@ const users_1 = __importDefault(require("./routes/users"));
 const modules_1 = __importDefault(require("./routes/modules"));
 const notifications_1 = __importDefault(require("./routes/notifications"));
 const progress_1 = __importDefault(require("./routes/progress"));
+const tickets_1 = __importDefault(require("./routes/tickets"));
 const app = (0, express_1.default)();
 const PORT = process.env.PORT || 5000;
 app.use((0, cors_1.default)());
@@ -23,6 +24,7 @@ app.use('/api/users', users_1.default);
 app.use('/api/modules', modules_1.default);
 app.use('/api/notifications', notifications_1.default);
 app.use('/api/progress', progress_1.default);
+app.use('/api/tickets', tickets_1.default);
 app.get('/', (_req, res) => {
     res.send('🚀 Backend TS démarré !');
 });

--- a/backend/dist/models/ITicket.js
+++ b/backend/dist/models/ITicket.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/backend/dist/routes/tickets.js
+++ b/backend/dist/routes/tickets.js
@@ -1,0 +1,72 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const express_1 = require("express");
+const dataStore_1 = require("../config/dataStore");
+const notifier_1 = require("../utils/notifier");
+const router = (0, express_1.Router)();
+const TABLE = 'tickets';
+const mailRx = /^[a-z0-9]+(\.[a-z0-9]+)?@alten\.com$/i;
+function load() { return (0, dataStore_1.read)(TABLE); }
+function save(list) { (0, dataStore_1.write)(TABLE, list); }
+router.get('/', (_req, res) => {
+    res.json(load());
+});
+router.post('/', (req, res) => {
+    const { username, target, title, message } = req.body;
+    if (!username || !target || !title || !message)
+        return res.status(400).json({ error: 'Données manquantes' });
+    const users = (0, dataStore_1.read)('users');
+    const author = users.find(u => u.username === username);
+    const ticket = {
+        id: Date.now().toString(),
+        username,
+        managerId: author?.managerId,
+        target: target,
+        title,
+        message,
+        status: 'open',
+        date: new Date().toISOString(),
+    };
+    const list = load();
+    list.push(ticket);
+    save(list);
+    const admins = users
+        .filter(u => u.role === 'admin' && mailRx.test(u.username))
+        .map(u => u.username);
+    const managerMail = ticket.managerId
+        ? users.find(u => u.id === ticket.managerId)?.username
+        : undefined;
+    const to = [];
+    if (ticket.target === 'admin' || ticket.target === 'both')
+        to.push(...admins);
+    if ((ticket.target === 'manager' || ticket.target === 'both') && managerMail && mailRx.test(managerMail))
+        to.push(managerMail);
+    (0, notifier_1.notify)({
+        username,
+        category: 'ticket',
+        message: `Nouveau ticket: ${title}`,
+        to,
+    }).catch(err => console.error('[TICKET]', err.message));
+    res.status(201).json(ticket);
+});
+router.patch('/:id', (req, res) => {
+    const { status } = req.body;
+    if (!status)
+        return res.status(400).json({ error: 'Statut manquant' });
+    const list = load();
+    const idx = list.findIndex(t => t.id === req.params.id);
+    if (idx === -1)
+        return res.status(404).json({ error: 'Introuvable' });
+    list[idx].status = status;
+    save(list);
+    const ticket = list[idx];
+    const to = mailRx.test(ticket.username) ? [ticket.username] : [];
+    (0, notifier_1.notify)({
+        username: ticket.username,
+        category: 'ticket',
+        message: `Mise à jour du ticket "${ticket.title}" : ${status}`,
+        to,
+    }).catch(err => console.error('[TICKET]', err.message));
+    res.json(ticket);
+});
+exports.default = router;

--- a/backend/dist/routes/users.js
+++ b/backend/dist/routes/users.js
@@ -9,7 +9,7 @@ const dataStore_1 = require("../config/dataStore");
 const router = (0, express_1.Router)();
 const TABLE = 'users';
 const hash = (pwd) => bcrypt_1.default.hashSync(pwd, 8);
-const mailRx = /^[a-z]+.[a-z][+@alten.com]$/i;
+const mailRx = /^[a-z0-9]+(\.[a-z0-9]+)?@alten\.com$/i;
 /* ───────────── GET liste complète ───────────── */
 router.get('/', (_req, res) => {
     const { managerId } = _req.query;

--- a/backend/dist/utils/mailer.js
+++ b/backend/dist/utils/mailer.js
@@ -10,7 +10,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.sendMail = void 0;
 const nodemailer_1 = __importDefault(require("nodemailer"));
 /* ---------- variables d’env. ---------- */
-const { MAIL_USER = '', // ex. [services@conforea.fr](mailto:services@conforea.fr)
+const { MAIL_USER = '', // ex. services@conforea.fr
 MAIL_PASS = '', // ex. Test2025!
 MAIL_HOST = 'ns0.ovh.net', // hôte SMTP OVH
  } = process.env;

--- a/backend/dist/utils/notifier.js
+++ b/backend/dist/utils/notifier.js
@@ -1,0 +1,22 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.notify = void 0;
+const dataStore_1 = require("../config/dataStore");
+const mailer_1 = require("./mailer");
+const TABLE = 'notifications';
+async function notify(options) {
+    const list = (0, dataStore_1.read)(TABLE);
+    const entry = {
+        id: Date.now().toString(),
+        username: options.username,
+        date: new Date().toISOString(),
+        category: options.category,
+        message: options.message,
+    };
+    list.push(entry);
+    (0, dataStore_1.write)(TABLE, list);
+    if (options.to.length > 0) {
+        await (0, mailer_1.sendMail)(options.to, 'CAF\u2011Trainer notification', `<p>${options.message}</p>`);
+    }
+}
+exports.notify = notify;

--- a/backend/src/data/notifications.json
+++ b/backend/src/data/notifications.json
@@ -1,170 +1,352 @@
 [
-{
+  {
     "id": "1746780767747",
     "username": "camile.briard@alten.com",
     "date": "2025-05-09T08:52:47.747Z",
     "message": "Demande de réinitialisation de mot de passe"
-},
-{
+  },
+  {
     "id": "1746781008943",
     "username": "camile.briard@alten.com",
     "date": "2025-05-09T08:56:48.943Z",
     "message": "Demande de réinitialisation de mot de passe"
-},
-{
+  },
+  {
     "id": "1746781115632",
     "username": "camile.briard@alten.com",
     "date": "2025-05-09T08:58:35.632Z",
     "message": "Demande de réinitialisation de mot de passe"
-},
-{
+  },
+  {
     "id": "1746781182642",
     "username": "camile.briard@alten.com",
     "date": "2025-05-09T08:59:42.642Z",
     "message": "Demande de réinitialisation de mot de passe"
-},
-{
+  },
+  {
     "id": "1746781574203",
     "username": "camile.briard@alten.com",
     "date": "2025-05-09T09:06:14.203Z",
     "message": "Demande de réinitialisation de mot de passe"
-},
-{
+  },
+  {
     "id": "1746781682846",
     "username": "camile.briard@alten.com",
     "date": "2025-05-09T09:08:02.846Z",
     "message": "Demande de réinitialisation de mot de passe"
-},
-{
+  },
+  {
     "id": "1746782228489",
     "username": "camile.briard@alten.com",
     "date": "2025-05-09T09:17:08.489Z",
     "message": "Demande de réinitialisation de mot de passe"
-},
-{
+  },
+  {
     "id": "1746782870084",
     "username": "camile.briard@alten.com",
     "date": "2025-05-09T09:27:50.084Z",
     "message": "Demande de réinitialisation de mot de passe"
-},
-{
+  },
+  {
     "id": "1746783502881",
     "username": "camile.briard@alten.com",
     "date": "2025-05-09T09:38:22.881Z",
     "message": "Demande de réinitialisation de mot de passe"
-},
-{
+  },
+  {
     "id": "1746786218411",
     "username": "camile.briard@alten.com",
     "date": "2025-05-09T10:23:38.411Z",
     "message": "Demande de réinitialisation de mot de passe"
-},
-{
+  },
+  {
     "id": "1746786447373",
     "username": "camile.briard@alten.com",
     "date": "2025-05-09T10:27:27.373Z",
     "message": "Demande de réinitialisation de mot de passe"
-},
-{
+  },
+  {
     "id": "1746786888133",
     "username": "camile.briard@alten.com",
     "date": "2025-05-09T10:34:48.133Z",
     "message": "Demande de réinitialisation de mot de passe"
-},
-{
+  },
+  {
     "id": "1746786900948",
     "username": "camile.briard@alten.com",
     "date": "2025-05-09T10:35:00.948Z",
     "message": "Demande de réinitialisation de mot de passe"
-},
-{
+  },
+  {
     "id": "1746787363372",
     "username": "prenom.nom@alten.com",
     "date": "2025-05-09T10:42:43.372Z",
     "message": "Demande de réinitialisation de mot de passe"
-},
-{
+  },
+  {
     "id": "1746787767646",
     "username": "prenom.nom@alten.com",
     "date": "2025-05-09T10:49:27.646Z",
     "message": "Demande de réinitialisation de mot de passe"
-},
-{
+  },
+  {
     "id": "1746787817309",
     "username": "prenom.nom@alten.com",
     "date": "2025-05-09T10:50:17.309Z",
     "message": "Demande de réinitialisation de mot de passe"
-},
-{
+  },
+  {
     "id": "1746788016089",
     "username": "prenom.nom@alten.com",
     "date": "2025-05-09T10:53:36.089Z",
     "message": "Demande de réinitialisation de mot de passe"
-},
-{
+  },
+  {
     "id": "1746788349599",
     "username": "prenom.nom@alten.com",
     "date": "2025-05-09T10:59:09.599Z",
     "message": "Demande de réinitialisation de mot de passe"
-},
-{
+  },
+  {
     "id": "1746793178364",
     "username": "prenom.nom@alten.com",
     "date": "2025-05-09T12:19:38.364Z",
     "message": "Demande de réinitialisation de mot de passe"
-},
-{
+  },
+  {
     "id": "1746793235787",
     "username": "prenom.nom@alten.com",
     "date": "2025-05-09T12:20:35.787Z",
     "message": "Demande de réinitialisation de mot de passe"
-},
-{
+  },
+  {
     "id": "1746793424595",
     "username": "prenom.nom@alten.com",
     "date": "2025-05-09T12:23:44.595Z",
     "message": "Demande de réinitialisation de mot de passe"
-},
-{
+  },
+  {
     "id": "1746793822845",
     "username": "prenom.nom@alten.com",
     "date": "2025-05-09T12:30:22.845Z",
     "message": "Demande de réinitialisation de mot de passe"
-},
-{
+  },
+  {
     "id": "1746793955042",
     "username": "prenom.nom@alten.com",
     "date": "2025-05-09T12:32:35.042Z",
     "message": "Demande de réinitialisation de mot de passe"
-},
-{
+  },
+  {
     "id": "1746795267922",
     "username": "prenom.nom@alten.com",
     "date": "2025-05-09T12:54:27.922Z",
     "message": "Demande de réinitialisation de mot de passe"
-},
-{
+  },
+  {
     "id": "1746795447159",
     "username": "prenom.nom@alten.com",
     "date": "2025-05-09T12:57:27.159Z",
     "message": "Demande de réinitialisation de mot de passe"
-},
-{
+  },
+  {
     "id": "1746795887508",
     "username": "prenom.nom@alten.com",
     "date": "2025-05-09T13:04:47.508Z",
     "message": "Demande de réinitialisation de mot de passe"
-},
-{
+  },
+  {
     "id": "1747039038994",
     "username": "prenom.nom@alten.com",
     "date": "2025-05-12T08:37:18.994Z",
     "message": "Demande de réinitialisation de mot de passe"
-},
-{
+  },
+  {
     "id": "1747126678141",
     "username": "prenom.nom@alten.com",
     "date": "2025-05-13T08:57:58.141Z",
     "message": "Demande de réinitialisation de mot de passe"
-}
+  },
+  {
+    "id": "1747919408711",
+    "username": "logan",
+    "date": "2025-05-22T13:10:08.711Z",
+    "category": "ticket",
+    "message": "Nouveau ticket: CAF Trainer bug"
+  },
+  {
+    "id": "1747919440847",
+    "username": "logan",
+    "date": "2025-05-22T13:10:40.847Z",
+    "category": "ticket",
+    "message": "Mise à jour du ticket \"CAF Trainer bug\" : open"
+  },
+  {
+    "id": "1747919442328",
+    "username": "logan",
+    "date": "2025-05-22T13:10:42.328Z",
+    "category": "ticket",
+    "message": "Mise à jour du ticket \"CAF Trainer bug\" : open"
+  },
+  {
+    "id": "1747919444230",
+    "username": "logan",
+    "date": "2025-05-22T13:10:44.230Z",
+    "category": "ticket",
+    "message": "Mise à jour du ticket \"CAF Trainer bug\" : open"
+  },
+  {
+    "id": "1747919445283",
+    "username": "logan",
+    "date": "2025-05-22T13:10:45.283Z",
+    "category": "ticket",
+    "message": "Mise à jour du ticket \"CAF Trainer bug\" : open"
+  },
+  {
+    "id": "1747919447180",
+    "username": "logan",
+    "date": "2025-05-22T13:10:47.180Z",
+    "category": "ticket",
+    "message": "Mise à jour du ticket \"CAF Trainer bug\" : open"
+  },
+  {
+    "id": "1747919449245",
+    "username": "logan",
+    "date": "2025-05-22T13:10:49.245Z",
+    "category": "ticket",
+    "message": "Mise à jour du ticket \"CAF Trainer bug\" : pending"
+  },
+  {
+    "id": "1747919450928",
+    "username": "logan",
+    "date": "2025-05-22T13:10:50.928Z",
+    "category": "ticket",
+    "message": "Mise à jour du ticket \"CAF Trainer bug\" : open"
+  },
+  {
+    "id": "1747919454230",
+    "username": "logan",
+    "date": "2025-05-22T13:10:54.230Z",
+    "category": "ticket",
+    "message": "Mise à jour du ticket \"CAF Trainer bug\" : closed"
+  },
+  {
+    "id": "1747919462299",
+    "username": "logan",
+    "date": "2025-05-22T13:11:02.299Z",
+    "category": "ticket",
+    "message": "Mise à jour du ticket \"CAF Trainer bug\" : pending"
+  },
+  {
+    "id": "1747919463279",
+    "username": "logan",
+    "date": "2025-05-22T13:11:03.279Z",
+    "category": "ticket",
+    "message": "Mise à jour du ticket \"CAF Trainer bug\" : open"
+  },
+  {
+    "id": "1747919464547",
+    "username": "logan",
+    "date": "2025-05-22T13:11:04.547Z",
+    "category": "ticket",
+    "message": "Mise à jour du ticket \"CAF Trainer bug\" : closed"
+  },
+  {
+    "id": "1747926340186",
+    "username": "logan",
+    "date": "2025-05-22T15:05:40.186Z",
+    "category": "ticket",
+    "message": "Nouveau ticket: test"
+  },
+  {
+    "id": "1747926552136",
+    "username": "logan",
+    "date": "2025-05-22T15:09:12.136Z",
+    "category": "ticket",
+    "message": "Nouveau ticket \"Test 2\": azertyuiop, juezlohfz 5245636."
+  },
+  {
+    "id": "1747926672483",
+    "username": "logan",
+    "date": "2025-05-22T15:11:12.483Z",
+    "category": "ticket",
+    "message": "Mise à jour du ticket \"test\" : pending"
+  },
+  {
+    "id": "1747926676945",
+    "username": "logan",
+    "date": "2025-05-22T15:11:16.945Z",
+    "category": "ticket",
+    "message": "Mise à jour du ticket \"test\" : open"
+  },
+  {
+    "id": "1747926678030",
+    "username": "logan",
+    "date": "2025-05-22T15:11:18.030Z",
+    "category": "ticket",
+    "message": "Mise à jour du ticket \"test\" : open"
+  },
+  {
+    "id": "1747926679687",
+    "username": "logan",
+    "date": "2025-05-22T15:11:19.687Z",
+    "category": "ticket",
+    "message": "Mise à jour du ticket \"test\" : pending"
+  },
+  {
+    "id": "1747926680287",
+    "username": "logan",
+    "date": "2025-05-22T15:11:20.287Z",
+    "category": "ticket",
+    "message": "Mise à jour du ticket \"test\" : pending"
+  },
+  {
+    "id": "1747926680939",
+    "username": "logan",
+    "date": "2025-05-22T15:11:20.939Z",
+    "category": "ticket",
+    "message": "Mise à jour du ticket \"test\" : open"
+  },
+  {
+    "id": "1747926681594",
+    "username": "logan",
+    "date": "2025-05-22T15:11:21.594Z",
+    "category": "ticket",
+    "message": "Mise à jour du ticket \"test\" : closed"
+  },
+  {
+    "id": "1747926694882",
+    "username": "logan",
+    "date": "2025-05-22T15:11:34.882Z",
+    "category": "ticket",
+    "message": "Mise à jour du ticket \"Test 2\" : closed"
+  },
+  {
+    "id": "1747926695300",
+    "username": "logan",
+    "date": "2025-05-22T15:11:35.300Z",
+    "category": "ticket",
+    "message": "Mise à jour du ticket \"test\" : closed"
+  },
+  {
+    "id": "1747926696119",
+    "username": "logan",
+    "date": "2025-05-22T15:11:36.119Z",
+    "category": "ticket",
+    "message": "Mise à jour du ticket \"CAF Trainer bug\" : closed"
+  },
+  {
+    "id": "1747926699383",
+    "username": "logan",
+    "date": "2025-05-22T15:11:39.383Z",
+    "category": "ticket",
+    "message": "Mise à jour du ticket \"Test 2\" : pending"
+  },
+  {
+    "id": "1747926700831",
+    "username": "logan",
+    "date": "2025-05-22T15:11:40.831Z",
+    "category": "ticket",
+    "message": "Mise à jour du ticket \"test\" : open"
+  }
 ]

--- a/backend/src/data/progress.json
+++ b/backend/src/data/progress.json
@@ -2,7 +2,12 @@
   {
     "username": "logan",
     "moduleId": "module-1",
-    "visited": []
+    "visited": [
+      "823615c7-a15f-464f-bd9c-369efe9e5660",
+      "601a451a-7e40-4004-b7d9-4d32baca0031",
+      "b83a25cb-12ac-4e4c-ad6b-6a1a4e324a8a",
+      "60f65965-ef9e-4541-8086-2569210ddab2"
+    ]
   },
   {
     "username": "user",

--- a/backend/src/data/tickets.json
+++ b/backend/src/data/tickets.json
@@ -1,1 +1,32 @@
-[]
+[
+  {
+    "id": "1747919408709",
+    "username": "logan",
+    "managerId": "1746634331825",
+    "target": "both",
+    "title": "CAF Trainer bug",
+    "message": "Je ne retrouve pas le lien pour acceder au site",
+    "status": "closed",
+    "date": "2025-05-22T13:10:08.709Z"
+  },
+  {
+    "id": "1747926340182",
+    "username": "logan",
+    "managerId": "1747838393929",
+    "target": "manager",
+    "title": "test",
+    "message": "test 123",
+    "status": "open",
+    "date": "2025-05-22T15:05:40.182Z"
+  },
+  {
+    "id": "1747926552130",
+    "username": "logan",
+    "managerId": "1747838393929",
+    "target": "manager",
+    "title": "Test 2",
+    "message": "azertyuiop, juezlohfz 5245636",
+    "status": "pending",
+    "date": "2025-05-22T15:09:12.130Z"
+  }
+]

--- a/backend/src/data/users.json
+++ b/backend/src/data/users.json
@@ -20,7 +20,7 @@
     "password": "$2b$08$9qrH.OwADfldwyPPd6UqaOah0gFEGob/Glhf4Pqp/w2HX3LVdcexG",
     "role": "caf",
     "site": "Nantes",
-    "managerId": "1746634331825"
+    "managerId": "1747838393929"
   },
   {
     "id": "1747039012242",

--- a/backend/src/models/INotification.ts
+++ b/backend/src/models/INotification.ts
@@ -1,6 +1,9 @@
+export type NotificationCategory = 'ticket' | 'password';
+
 export interface INotification {
-        id: string;
-        username: string;
-        date: string;
-        message?: string;
-    }
+  id: string;
+  username: string;
+  date: string;
+  category: NotificationCategory;
+  message?: string;
+}

--- a/backend/src/routes/tickets.ts
+++ b/backend/src/routes/tickets.ts
@@ -51,7 +51,7 @@ router.post('/', (req, res) => {
   notify({
     username,
     category: 'ticket',
-    message: `Nouveau ticket: ${title}`,
+    message: `Nouveau ticket de ${username} intitulé "${title}" :       ${message}.`,
     to,
   }).catch(err => console.error('[TICKET]', (err as Error).message));
 

--- a/backend/src/utils/notifier.ts
+++ b/backend/src/utils/notifier.ts
@@ -1,0 +1,28 @@
+import { read, write } from '../config/dataStore';
+import { sendMail } from './mailer';
+import { INotification, NotificationCategory } from '../models/INotification';
+
+const TABLE = 'notifications';
+
+export interface NotifyOptions {
+  username: string;
+  category: NotificationCategory;
+  message: string;
+  to: string[];
+}
+
+export async function notify(options: NotifyOptions): Promise<void> {
+  const list = read<INotification>(TABLE);
+  const entry: INotification = {
+    id: Date.now().toString(),
+    username: options.username,
+    date: new Date().toISOString(),
+    category: options.category,
+    message: options.message,
+  };
+  list.push(entry);
+  write(TABLE, list);
+  if (options.to.length > 0) {
+    await sendMail(options.to, 'CAF\u2011Trainer notification', `<p>${options.message}</p>`);
+  }
+}

--- a/client/src/pages/NotificationsPage.tsx
+++ b/client/src/pages/NotificationsPage.tsx
@@ -2,10 +2,11 @@ import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 
-interface INotification {         /* ← typage local */
+interface INotification {
   id: string;
   username: string;
   date: string;
+  category: string;
   message?: string;
 }
 
@@ -23,7 +24,7 @@ export default function NotificationsPage() {
   return (
     <Wrapper>
       <button className="btn-back" onClick={() => navigate(-1)}>← Retour</button>
-      <h2>Demandes de mot de passe oublié</h2>
+      <h2>Notifications</h2>
       {notifs.length === 0
         ? <p>Aucune notification.</p>
         : (
@@ -31,6 +32,7 @@ export default function NotificationsPage() {
             {notifs.map(n => (
               <li key={n.id}>
                 {n.username} – {new Date(n.date).toLocaleString()}
+                {n.message ? ` – ${n.message}` : ''}
               </li>
             ))}
           </ul>


### PR DESCRIPTION
## Summary
- create centralized `notify` helper
- extend notifications model with a category field
- trigger notifications when tickets are created or updated
- send notification emails for forgotten password using the new helper
- show notification messages in the UI

## Testing
- `npm --workspace backend run build`
- `CI=true npm --workspace client test -- --passWithNoTests`
