### PR TITLE
Add item status logic with help editor

### DIFF
--- a/client/src/api/userProgress.ts
+++ b/client/src/api/userProgress.ts
@@ -1,0 +1,27 @@
+import axios from 'axios';
+
+export type ItemStatus =
+  | 'non_commencé'
+  | 'en_cours'
+  | 'besoin_aide'
+  | 'terminé'
+  | 'soumis_validation'
+  | 'en_attente'
+  | 'validé';
+
+export const updateItemStatus = async (
+  userId: string,
+  itemId: string,
+  status: ItemStatus
+) => {
+  await axios.patch(`/api/user-progress/${userId}/items/${itemId}/status`, { status });
+};
+
+export const sendHelpRequest = async (
+  userId: string,
+  itemId: string,
+  message: string,
+  email?: string
+) => {
+  await axios.post(`/api/user-progress/${userId}/items/${itemId}/help-request`, { message, email });
+};

--- a/client/src/components/AdvancedHelpEditor.tsx
+++ b/client/src/components/AdvancedHelpEditor.tsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+import AdvancedEditor from './AdvancedEditor';
+
+export interface AdvancedHelpEditorProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (msg: string) => void;
+}
+
+export default function AdvancedHelpEditor({ open, onClose, onSubmit }: AdvancedHelpEditorProps) {
+  const [msg, setMsg] = useState('');
+  if (!open) return null;
+
+  return (
+    <div
+      style={{
+        position: 'fixed', top: 0, left: 0, right: 0, bottom: 0,
+        background: 'rgba(0,0,0,0.5)', display: 'flex', alignItems: 'center', justifyContent: 'center',
+        zIndex: 2000,
+      }}
+    >
+      <div style={{ background: '#fff', padding: '1rem', borderRadius: 8, width: '90%', maxWidth: 600 }}>
+        <h3>Demande d'aide</h3>
+        <AdvancedEditor value={msg} onChange={setMsg} />
+        <div style={{ marginTop: 8, textAlign: 'right' }}>
+          <button onClick={() => { onSubmit(msg); setMsg(''); }}>Envoyer</button>
+          <button style={{ marginLeft: 8 }} onClick={onClose}>Fermer</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/ItemContent.tsx
+++ b/client/src/components/ItemContent.tsx
@@ -6,6 +6,7 @@ import FavoriteButton from './FavoriteButton';
 import Quiz from './Quiz';
 import './ItemContent.css';
 import { IImage, ILink, IQuiz } from '../api/modules';
+import { ItemStatus } from '../api/userProgress';
       
 export interface ItemContentProps {
   /* ─── contenu ─── */
@@ -19,6 +20,11 @@ export interface ItemContentProps {
   quiz?:       IQuiz;
   quizPassed?: boolean;
   onQuizPassed?: () => void;
+
+  /* ─── statut ─── */
+  status: ItemStatus;
+  onStatusChange: (st: ItemStatus) => void;
+  onHelpRequest: () => void;
       
                   /* ─── progression ─── */
                   isVisited:        boolean;
@@ -37,7 +43,18 @@ export interface ItemContentProps {
     quiz, quizPassed, onQuizPassed,
     isVisited, onToggleVisited,
     isFav,     onToggleFav,
+    status, onStatusChange, onHelpRequest,
   } = props;
+
+  const icons: Record<ItemStatus, string> = {
+    non_commencé: '▶️',
+    en_cours: '🕓',
+    besoin_aide: '🆘',
+    terminé: '🎉',
+    soumis_validation: '📤',
+    en_attente: '⏱️',
+    validé: '✅',
+  };
       
                   return (
                     <div className="item-content">
@@ -61,6 +78,7 @@ export interface ItemContentProps {
       
                           {/* étoile favoris */}
                           <FavoriteButton isFav={isFav} onClick={onToggleFav} />
+                          <span>{icons[status]}</span>
                         </div>
                       </div>
       
@@ -119,6 +137,21 @@ export interface ItemContentProps {
                       {quiz && quiz.enabled && (
                         <Quiz quiz={quiz} onSuccess={onQuizPassed ?? (()=>{})} passed={quizPassed ?? false} />
                       )}
+
+                      {/* -------- actions statut -------- */}
+                      <div style={{ marginTop: 16 }}>
+                        {status === 'non_commencé' && (
+                          <button onClick={() => onStatusChange('en_cours')}>▶️ Démarrer</button>
+                        )}
+                        {status === 'en_cours' && (
+                          <>
+                            <button onClick={() => onStatusChange(quiz ? 'soumis_validation' : 'terminé')}>
+                              {quiz ? '📤 Soumettre' : '✅ Terminer'}
+                            </button>
+                            <button onClick={onHelpRequest} style={{ marginLeft: 8 }}>🆘 Besoin d'aide</button>
+                          </>
+                        )}
+                      </div>
                     </div>
                   );
                 }


### PR DESCRIPTION
## Summary
- track item statuses in local storage and backend
- add API helpers for user progress
- display status icon and actions in `ItemContent`
- integrate help request editor and status updates in module and prerequis pages

## Testing
- `npx tsc --noEmit` *(fails: Cannot use JSX unless the '--jsx' flag is provided)*