### PR TITLE
Add item validation options

### DIFF
--- a/backend/src/models/IModule.ts
+++ b/backend/src/models/IModule.ts
@@ -31,6 +31,9 @@ videos:    string[];
   profiles:  string[];
   enabled:   boolean;
 
+  requiresValidation?: boolean;
+  validationMode?: 'quiz' | 'manual';
+
   quiz?: IQuiz;
 
   children?: IItem[];

--- a/client/src/api/modules.ts
+++ b/client/src/api/modules.ts
@@ -37,6 +37,9 @@ export interface IItem  {
   profiles:  string[];
   enabled:   boolean;
 
+  requiresValidation?: boolean;
+  validationMode?: 'quiz' | 'manual';
+
   quiz?: IQuiz;
 
   children?: IItem[];

--- a/client/src/components/ItemContent.tsx
+++ b/client/src/components/ItemContent.tsx
@@ -21,6 +21,9 @@ export interface ItemContentProps {
   quizPassed?: boolean;
   onQuizPassed?: () => void;
 
+  requiresValidation?: boolean;
+  validationMode?: 'quiz' | 'manual';
+
   /* ─── statut ─── */
   status: ItemStatus;
   onStatusChange: (st: ItemStatus) => void;
@@ -41,6 +44,7 @@ export interface ItemContentProps {
   const {
     title, subtitle, description, links = [], images, videos,
     quiz, quizPassed, onQuizPassed,
+    requiresValidation = false, validationMode = 'manual',
     isVisited, onToggleVisited,
     isFav,     onToggleFav,
     status, onStatusChange, onHelpRequest,
@@ -135,7 +139,16 @@ export interface ItemContentProps {
                       ) : null}
 
                       {quiz && quiz.enabled && (
-                        <Quiz quiz={quiz} onSuccess={onQuizPassed ?? (()=>{})} passed={quizPassed ?? false} />
+                        <Quiz
+                          quiz={quiz}
+                          onSuccess={() => {
+                            onQuizPassed?.();
+                            if (requiresValidation && validationMode === 'quiz') {
+                              onStatusChange('validé');
+                            }
+                          }}
+                          passed={quizPassed ?? false}
+                        />
                       )}
 
                       {/* -------- actions statut -------- */}
@@ -145,9 +158,12 @@ export interface ItemContentProps {
                         )}
                         {status === 'en_cours' && (
                           <>
-                            <button onClick={() => onStatusChange(quiz ? 'soumis_validation' : 'terminé')}>
-                              {quiz ? '📤 Soumettre' : '✅ Terminer'}
-                            </button>
+                            {!requiresValidation && (
+                              <button onClick={() => onStatusChange('terminé')}>✅ Terminer</button>
+                            )}
+                            {requiresValidation && validationMode === 'manual' && (
+                              <button onClick={() => onStatusChange('en_attente')}>📤 Soumettre</button>
+                            )}
                             <button onClick={onHelpRequest} style={{ marginLeft: 8 }}>🆘 Besoin d'aide</button>
                           </>
                         )}

--- a/client/src/components/ModuleEditor.css
+++ b/client/src/components/ModuleEditor.css
@@ -40,4 +40,10 @@
       
              button.primary      { background:#008bd2; color:#fff; border:none;
                                    padding:8px 16px; border-radius:4px; cursor:pointer; }
-             button.primary:hover{ background:#006fa1; }
+button.primary:hover{ background:#006fa1; }
+
+.validation-options {
+  margin: 0 0 8px 24px;
+  display: flex;
+  gap: 16px;
+}

--- a/client/src/components/ModuleEditor.tsx
+++ b/client/src/components/ModuleEditor.tsx
@@ -10,26 +10,28 @@ import {
       
                 /* ═════════════════════════ HELPERS GÉNÉRIAUX ═════════════════════════ */
       
-                const defaultImg = (i: Partial<IImage>): IImage => ({
-                  src:   i.src   ?? '',
-                  width: i.width ?? 100,
-                  align: i.align ?? 'left',
-                });
-      
-                const ensureDefaults = (it: Partial<IItem>): IItem => ({
-                  id:        it.id        ?? crypto.randomUUID(),
-                  title:     it.title     ?? '',
-                  subtitle:  it.subtitle  ?? '',
-                  content:   it.content   ?? '',
-                  links:     it.links     ?? [],
-                  images:    (it.images   ?? []).map((img: any) =>
-                               typeof img === 'string' ? defaultImg({ src: img }) : defaultImg(img)),
-                  videos:    it.videos    ?? [],
-                  profiles:  it.profiles  ?? [],
-                  enabled:   it.enabled   ?? true,
-                  quiz:      it.quiz      ?? { enabled: false, questions: [] },
-                  children:  (it.children ?? []).map(ensureDefaults),
-                });
+  const defaultImg = (i: Partial<IImage>): IImage => ({
+    src:   i.src   ?? '',
+    width: i.width ?? 100,
+    align: i.align ?? 'left',
+  });
+
+  const ensureDefaults = (it: Partial<IItem>): IItem => ({
+    id:        it.id        ?? crypto.randomUUID(),
+    title:     it.title     ?? '',
+    subtitle:  it.subtitle  ?? '',
+    content:   it.content   ?? '',
+    links:     it.links     ?? [],
+    images:    (it.images   ?? []).map((img: any) =>
+                 typeof img === 'string' ? defaultImg({ src: img }) : defaultImg(img)),
+    videos:    it.videos    ?? [],
+    profiles:  it.profiles  ?? [],
+    enabled:   it.enabled   ?? true,
+    requiresValidation: it.requiresValidation ?? false,
+    validationMode:     it.validationMode     ?? 'manual',
+    quiz:      it.quiz      ?? { enabled: false, questions: [] },
+    children:  (it.children ?? []).map(ensureDefaults),
+  });
       
 // parcours récursif de l'arbre en appliquant fn sur chaque item
 // (prend en compte les éventuelles modifications de `children` retournées
@@ -436,12 +438,46 @@ const ModuleEditor = forwardRef<ModuleEditorHandle, Props>(
                               </div>
                             )}
                           </fieldset>
-      
-                            <label className="inline-row">
-                              <input
-                                type="checkbox"
-                                checked={current.enabled}
-                                onChange={(e) => patchItem({ enabled: e.target.checked })}
+
+                          <label className="inline-row">
+                            <input
+                              type="checkbox"
+                              checked={current.requiresValidation ?? false}
+                              onChange={e => patchItem({ requiresValidation: e.target.checked })}
+                            />{' '}
+                            Validation requise ?
+                          </label>
+
+                          {current.requiresValidation && (
+                            <div className="validation-options">
+                              <label>
+                                <input
+                                  type="radio"
+                                  name={`val-${current.id}`}
+                                  value="quiz"
+                                  checked={current.validationMode === 'quiz'}
+                                  onChange={() => patchItem({ validationMode: 'quiz' })}
+                                />{' '}
+                                Par quiz (automatique)
+                              </label>
+                              <label>
+                                <input
+                                  type="radio"
+                                  name={`val-${current.id}`}
+                                  value="manual"
+                                  checked={current.validationMode === 'manual'}
+                                  onChange={() => patchItem({ validationMode: 'manual' })}
+                                />{' '}
+                                Par manager (validation manuelle)
+                              </label>
+                            </div>
+                          )}
+
+                          <label className="inline-row">
+                            <input
+                              type="checkbox"
+                              checked={current.enabled}
+                              onChange={(e) => patchItem({ enabled: e.target.checked })}
                               />{' '}
                               Item actif
                             </label>

--- a/client/src/pages/ModulePage.tsx
+++ b/client/src/pages/ModulePage.tsx
@@ -121,7 +121,11 @@ export default function ModulePage() {
   const toggleVisited = (id: string) =>
     setVis((prev) => {
       const item = find(id)!;
-      if (item.quiz?.enabled && !quizPassed[id]) {
+      if (
+        item.requiresValidation &&
+        item.validationMode === 'quiz' &&
+        !quizPassed[id]
+      ) {
         alert('Vous devez réussir le quiz avant de valider cet item.');
         return prev;
       }
@@ -143,6 +147,10 @@ export default function ModulePage() {
     setQuizPassed(prev => {
       const next = { ...prev, [id]: true };
       localStorage.setItem(`quiz_${moduleId}`, JSON.stringify(next));
+      const item = find(id)!;
+      if (item.requiresValidation && item.validationMode === 'quiz') {
+        changeStatus(id, 'validé');
+      }
       return next;
     });
   };
@@ -237,6 +245,8 @@ export default function ModulePage() {
           quiz={item.quiz}
           quizPassed={quizPassed[item.id]}
           onQuizPassed={() => markQuizPassed(item.id)}
+          requiresValidation={item.requiresValidation}
+          validationMode={item.validationMode}
           isVisited={visited.includes(item.id)}
           onToggleVisited={() => toggleVisited(item.id)}
           isFav={favs.includes(item.id)}

--- a/client/src/pages/PrerequisPage.tsx
+++ b/client/src/pages/PrerequisPage.tsx
@@ -98,6 +98,8 @@ import { ItemStatus, updateItemStatus, sendHelpRequest } from '../api/userProgre
               links={item.links}
 
                videos={item.videos}
+              requiresValidation={item.requiresValidation}
+              validationMode={item.validationMode}
               isVisited={visitedIds.includes(item.id)}
               onToggleVisited={() => toggleVisited(item.id)}
               isFav={favs.includes(item.id)}


### PR DESCRIPTION
## Summary
- enable validation config for items
- let module editor toggle item validation with CSS for options
- auto-validate by quiz or send item for manual validation
- track validation and quiz results in module page and item page
- update shared interfaces for new fields

## Testing
- `npm --workspace backend run build`
- `npm --workspace client run build`
- `npm --workspace client test --silent`