### PR TITLE
Refactor status workflow

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -56,7 +56,7 @@ function RoleRoutes() {
         <Route path="/manager/modules/:moduleId"   element={<AdminModuleEditor />} />
         <Route path="/manager/tickets"            element={<TicketsListPage />} />
         <Route path="/manager/tickets/new"        element={<CreateTicketPage />} />
-        <Route path="/admin/validations"          element={<ValidationsPage />} />
+        <Route path="/manager/validations"        element={<ValidationsPage />} />
         <Route path="/admin/*"                     element={<Navigate to="/manager" replace />} />
         <Route path="*"                            element={<Navigate to="/manager" replace />} />
       </Routes>
@@ -73,7 +73,6 @@ function RoleRoutes() {
         <Route path="/admin/prerequis"             element={<PrerequisAdminPage />} />
         <Route path="/admin/notifications"         element={<NotificationsPage />} />
         <Route path="/admin/tickets"               element={<TicketsListPage />} />
-        <Route path="/admin/validations"          element={<ValidationsPage />} />
         <Route path="/admin/create"                element={<RegisterUserPage />} />
 
         <Route path="/"   element={<Navigate to="/admin" replace />} />

--- a/client/src/components/ItemContent.css
+++ b/client/src/components/ItemContent.css
@@ -26,22 +26,13 @@
                      align-items: center;
                      gap: 12px;
                    }
-                   .check-button {
-                     background: none;
-                     border: none;
-                     cursor: pointer;
-                     padding: 4px;
-                     display: flex;
-                     align-items: center;
-                     color: #0870e7;
-                   }
-                   .check-button svg {
-                     font-size: 24px;
-                     transition: opacity .2s;
-                   }
-                   .check-button svg.unchecked { opacity: .5; }
-                   .check-button:hover svg,
-                   .check-button svg.checked { opacity: 1; }
+.status-button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 24px;
+  color: #0870e7;
+}
 .item-body {
   margin-top: 16px;
 }

--- a/client/src/components/ItemContent.tsx
+++ b/client/src/components/ItemContent.tsx
@@ -28,10 +28,7 @@ export interface ItemContentProps {
   status: ItemStatus;
   onStatusChange: (st: ItemStatus) => void;
   onHelpRequest: () => void;
-      
-                  /* ─── progression ─── */
-                  isVisited:        boolean;
-                  onToggleVisited:  () => void;
+
       
                   /* ─── favoris ─── */
                   isFav:       boolean;
@@ -45,7 +42,6 @@ export interface ItemContentProps {
     title, subtitle, description, links = [], images, videos,
     quiz, quizPassed, onQuizPassed,
     requiresValidation = false, validationMode = 'manual',
-    isVisited, onToggleVisited,
     isFav,     onToggleFav,
     status, onStatusChange, onHelpRequest,
   } = props;
@@ -59,6 +55,18 @@ export interface ItemContentProps {
     en_attente: '⏱️',
     validé: '✅',
   };
+
+  const handleStatusClick = () => {
+    if (status === 'non_commencé') {
+      onStatusChange('en_cours');
+    } else if (status === 'en_cours') {
+      if (requiresValidation && validationMode === 'manual') {
+        onStatusChange('en_attente');
+      } else if (!requiresValidation) {
+        onStatusChange('terminé');
+      }
+    }
+  };
       
                   return (
                     <div className="item-content">
@@ -70,19 +78,16 @@ export interface ItemContentProps {
         </div>
       
                         <div className="item-actions">
-                          {/* coche “vu” */}
-                          <button
-                            type="button"
-                            className="check-button"
-                            onClick={onToggleVisited}
-                            aria-label={isVisited ? 'Marquer non visité' : 'Marquer visité'}
-                          >
-                            {isVisited ? '✅' : '⭕'}
-                          </button>
-      
                           {/* étoile favoris */}
                           <FavoriteButton isFav={isFav} onClick={onToggleFav} />
-                          <span>{icons[status]}</span>
+                          <button
+                            type="button"
+                            className="status-button"
+                            onClick={handleStatusClick}
+                            aria-label="Changer le statut"
+                          >
+                            {icons[status]}
+                          </button>
                         </div>
                       </div>
       
@@ -153,19 +158,8 @@ export interface ItemContentProps {
 
                       {/* -------- actions statut -------- */}
                       <div style={{ marginTop: 16 }}>
-                        {status === 'non_commencé' && (
-                          <button onClick={() => onStatusChange('en_cours')}>▶️ Démarrer</button>
-                        )}
                         {status === 'en_cours' && (
-                          <>
-                            {!requiresValidation && (
-                              <button onClick={() => onStatusChange('terminé')}>✅ Terminer</button>
-                            )}
-                            {requiresValidation && validationMode === 'manual' && (
-                              <button onClick={() => onStatusChange('en_attente')}>📤 Soumettre</button>
-                            )}
-                            <button onClick={onHelpRequest} style={{ marginLeft: 8 }}>🆘 Besoin d'aide</button>
-                          </>
+                          <button onClick={onHelpRequest}>🆘 Besoin d'aide</button>
                         )}
                       </div>
                     </div>

--- a/client/src/pages/PrerequisPage.tsx
+++ b/client/src/pages/PrerequisPage.tsx
@@ -38,12 +38,6 @@ import { ItemStatus, updateItemStatus, sendHelpRequest } from '../api/userProgre
      }, []);
 
      /* ---------- helpers ---------- */
-     const toggleVisited = (id: string) =>
-       setVisited((prev) => {
-         const next = prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id];
-         localStorage.setItem(`visited_${MODULE_ID}`, JSON.stringify(next));
-         return next;
-       });
 
     const toggleFav = (id: string) =>
       setFavs((prev) => {
@@ -85,7 +79,7 @@ import { ItemStatus, updateItemStatus, sendHelpRequest } from '../api/userProgre
 
          <main className="content-area">
            <ProgressBar
-             current={visitedIds.length}
+             current={Object.values(statuses).filter(s => s === 'terminé' || s === 'validé').length}
              total={flatten(mod.items).length}
            />
 
@@ -100,8 +94,6 @@ import { ItemStatus, updateItemStatus, sendHelpRequest } from '../api/userProgre
                videos={item.videos}
               requiresValidation={item.requiresValidation}
               validationMode={item.validationMode}
-              isVisited={visitedIds.includes(item.id)}
-              onToggleVisited={() => toggleVisited(item.id)}
               isFav={favs.includes(item.id)}
               onToggleFav={() => toggleFav(item.id)}
               status={statuses[item.id] ?? 'non_commencé'}


### PR DESCRIPTION
## Summary
- make status icon clickable in item content
- drop check button and show help button only
- compute progress from item status instead of visited count
- show user names and item titles in validation page
- restrict validations route to manager path

## Testing
- `npm --workspace client run build`
- `npm --workspace backend run build`
