### PR TITLE
Add started tracking and fetch progress from backend

### DIFF
--- a/backend/src/models/IProgress.ts
+++ b/backend/src/models/IProgress.ts
@@ -1,5 +1,6 @@
 export interface IProgress {
-        username: string;           // identifiant CAF
-        moduleId: string;
-        visited:  string[];         // IDs d’items
-    }
+  username: string;           // identifiant CAF
+  moduleId: string;
+  started: string[];          // IDs d’items démarrés/en cours
+  visited: string[];          // IDs d’items terminés
+}

--- a/backend/src/routes/progress.ts
+++ b/backend/src/routes/progress.ts
@@ -1,6 +1,6 @@
              import { Router } from 'express';
              import { read, write } from '../config/dataStore';
-             import { IProgress }  from '../models/IProgress';
+import { IProgress }  from '../models/IProgress';
              import { IUser }      from '../models/IUser';
       
              const router = Router();
@@ -13,19 +13,37 @@
              });
       
              /* PATCH /api/progress   body:{ username,moduleId,visited } – MAJ 1 module */
-             router.patch('/', (req, res) => {
-               const { username, moduleId, visited } = req.body as IProgress;
-               if (!username || !moduleId) return res.status(400).json({error:'Données manquantes'});
-      
-               const list = read<IProgress>(TABLE);
-               const idx  = list.findIndex(p => p.username===username && p.moduleId===moduleId);
-      
-               if (idx === -1) list.push({ username, moduleId, visited });
-               else            list[idx].visited = visited;
-      
-               write(TABLE, list);
-               res.json({ ok:true });
-             });
+router.patch('/', (req, res) => {
+  const {
+    username,
+    moduleId,
+    visited = [],
+    started = [],
+  } = req.body as Partial<IProgress>;
+  if (!username || !moduleId) {
+    return res.status(400).json({ error: 'Données manquantes' });
+  }
+
+  const uniqVisited = Array.from(new Set(visited));
+  const uniqStarted = Array.from(new Set(started)).filter(
+    (id) => !uniqVisited.includes(id),
+  );
+
+  const list = read<IProgress>(TABLE);
+  const idx = list.findIndex(
+    (p) => p.username === username && p.moduleId === moduleId,
+  );
+
+  if (idx === -1) {
+    list.push({ username, moduleId, visited: uniqVisited, started: uniqStarted });
+  } else {
+    list[idx].visited = uniqVisited;
+    list[idx].started = uniqStarted;
+  }
+
+  write(TABLE, list);
+  res.json({ ok: true });
+});
       
              /* GET /api/progress?managerId=… – progression de tous les CAF d’un manager */
              router.get('/', (req, res) => {

--- a/client/src/api/modules.ts
+++ b/client/src/api/modules.ts
@@ -52,7 +52,8 @@ export interface IModule {
 export interface IProgress {
   username: string;          // CAF
   moduleId: string;
-  visited:  string[];        // ids d’items complétés
+  started: string[];         // ids d'items démarrés
+  visited: string[];         // ids d’items complétés
 }
       
       

--- a/client/src/components/ItemContent.css
+++ b/client/src/components/ItemContent.css
@@ -26,40 +26,63 @@
                      align-items: center;
                      gap: 12px;
                    }
-                   .check-button {
-                     background: none;
-                     border: none;
-                     cursor: pointer;
-                     padding: 4px;
-                     display: flex;
-                     align-items: center;
-                     color: #0870e7;
-                   }
-                   .check-button svg {
-                     font-size: 24px;
-                     transition: opacity .2s;
-                   }
-                   .check-button svg.unchecked { opacity: .5; }
-                   .check-button:hover svg,
-.check-button svg.checked { opacity: 1; }
+.check-button {
+  background: linear-gradient(135deg, #00c6ff, #0072ff);
+  border: none;
+  cursor: pointer;
+  padding: 8px 16px;
+  border-radius: 12px;
+  color: #fff;
+  font-size: 1rem;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+  transition: transform .2s;
+}
+.check-button:hover { transform: scale(1.05); }
 .status-label { font-weight: bold; }
 .item-body {
   margin-top: 16px;
 }
 .item-content { position: relative; }
-.item-content.new .item-inner { opacity: .6; }
+.item-content.new .item-inner {
+  opacity: .3;
+  pointer-events: none;
+}
 .start-overlay {
   position: absolute;
-  top: 8px;
-  left: 50%;
-  transform: translateX(-50%);
-  background: #008bd2;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(255,255,255,0.7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 2;
+}
+.start-overlay button {
+  font-size: 1.5rem;
+  padding: 12px 24px;
+  background: linear-gradient(135deg, #00c6ff, #0072ff);
   color: #fff;
   border: none;
-  padding: 8px 16px;
-  border-radius: 4px;
+  border-radius: 12px;
   cursor: pointer;
-  z-index: 2;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+  transition: transform .2s;
+}
+.start-overlay button:hover { transform: scale(1.05); }
+.confetti-piece {
+  position: fixed;
+  width: 8px;
+  height: 8px;
+  opacity: 0.9;
+  z-index: 1000;
+  animation: confetti-fall 1s linear forwards;
+}
+
+@keyframes confetti-fall {
+  from { transform: translateY(0) rotate(0); }
+  to { transform: translateY(-150px) rotate(720deg); opacity: 0; }
 }
 .item-body ul { padding-left: 20px; }
 .item-html p {

--- a/client/src/components/ItemContent.tsx
+++ b/client/src/components/ItemContent.tsx
@@ -42,15 +42,29 @@ export interface ItemContentProps {
   } = props;
       
   const cls = `item-content ${status}`;
+  const launchConfetti = (e: React.MouseEvent) => {
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    const x = (rect.left + rect.width / 2) / window.innerWidth;
+    const y = (rect.top + rect.height / 2) / window.innerHeight;
+    const colors = ['#00c6ff', '#0072ff', '#fce566', '#f98ec5'];
+    for (let i = 0; i < 150; i++) {
+      const div = document.createElement('div');
+      div.className = 'confetti-piece';
+      div.style.backgroundColor = colors[Math.floor(Math.random() * colors.length)];
+      div.style.left = `${x * 100}%`;
+      div.style.top = `${y * 100}%`;
+      div.style.transform = `translate(${(Math.random() - 0.5) * 200}px, ${(-Math.random()) * 200}px) rotate(${Math.random() * 720}deg)`;
+      document.body.appendChild(div);
+      setTimeout(() => div.remove(), 1000);
+    }
+  };
+
   return (
     <div className={cls}>
       {status === 'new' && (
-        <button
-          className="start-overlay"
-          onClick={() => onStatusChange('in-progress')}
-        >
-          Démarrer
-        </button>
+        <div className="start-overlay">
+          <button onClick={() => onStatusChange('in-progress')}>Démarrer</button>
+        </div>
       )}
       <div className="item-inner">
                       {/* -------- entête -------- */}
@@ -70,11 +84,10 @@ export interface ItemContentProps {
                             <button
                               type="button"
                               className="check-button"
-                              onClick={() => onStatusChange('done')}
+                              onClick={(e) => { launchConfetti(e); onStatusChange('done'); }}
                               disabled={quiz?.enabled && !quizPassed}
-                              aria-label="Marquer terminé"
                             >
-                              ✅
+                              Valider l'item ?
                             </button>
                           )}
 

--- a/client/src/pages/PrerequisPage.tsx
+++ b/client/src/pages/PrerequisPage.tsx
@@ -5,7 +5,7 @@
    import ItemContent, { ItemStatus }    from '../components/ItemContent';
    import ProgressBar    from '../components/ProgressBar';
    import { flatten, findById } from '../utils/items';
-   import { getModule, IItem, IModule } from '../api/modules';
+   import { getModule, IItem, IModule, IProgress } from '../api/modules';
    import { useAuth }     from '../context/AuthContext';
    import './PrerequisPage.css';
 
@@ -16,28 +16,48 @@
 
      const [mod, setMod]            = useState<IModule | null>(null);
      const [selectedId, setSelId ]  = useState<string>('');
-     const [status, setStatus] = useState<Record<string, ItemStatus>>(
-       () => JSON.parse(localStorage.getItem(`status_${MODULE_ID}`) ?? '{}'),
-     );
+    const [status, setStatus] = useState<Record<string, ItemStatus>>({});
      const [favs, setFavs] = useState<string[]>(
        () => JSON.parse(localStorage.getItem(favKey) ?? '[]'),
      );
 
      /* ---------- chargement module ---------- */
-     useEffect(() => {
-       getModule(MODULE_ID).then((m) => {
-         setMod(m);
-         setSelId(m.items[0]?.id ?? '');
-       });
-     }, []);
+    useEffect(() => {
+      getModule(MODULE_ID).then((m) => {
+        setMod(m);
+        setSelId(m.items[0]?.id ?? '');
+        if (user) {
+          fetch(`/api/progress/${user.username}`)
+            .then(r => r.json())
+            .then((rows: IProgress[]) => {
+              const row = rows.find(p => p.moduleId === MODULE_ID);
+              if (!row) return;
+              const st: Record<string, ItemStatus> = {};
+              row.started.forEach(id => { st[id] = 'in-progress'; });
+              row.visited.forEach(id => { st[id] = 'done'; });
+              setStatus(st);
+            })
+            .catch(console.error);
+        }
+      });
+    }, [user]);
 
      /* ---------- helpers ---------- */
-     const changeStatus = (id: string, s: ItemStatus) =>
-       setStatus((prev) => {
-         const next = { ...prev, [id]: s };
-         localStorage.setItem(`status_${MODULE_ID}`, JSON.stringify(next));
-         return next;
-       });
+    const changeStatus = (id: string, s: ItemStatus) =>
+      setStatus((prev) => {
+        const next = { ...prev, [id]: s };
+        if (user) {
+          const entries = Object.entries(next);
+          const visited = entries.filter(([,st])=>st==='done').map(([k])=>k);
+          const started = entries.filter(([,st])=>st==='in-progress').map(([k])=>k);
+          fetch('/api/progress', {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ username: user.username, moduleId: MODULE_ID, visited, started }),
+          }).catch(console.error);
+        }
+        return next;
+      });
 
      const toggleFav = (id: string) =>
        setFavs((prev) => {


### PR DESCRIPTION
## Summary
- keep track of items started without local storage
- fetch progress from `progress.json` instead of reading browser cache
- exclude validated items from started list in API
- adjust confetti animation to trigger from button center

## Testing
- `npm --workspace backend run build`
- `npm --workspace client run build`
