### PR TITLE
Add radar tracker to progress page

### DIFF
--- a/backend/src/data/progress.json
+++ b/backend/src/data/progress.json
@@ -3,12 +3,15 @@
     "username": "logan",
     "moduleId": "module-1",
     "visited": [
+      "823615c7-a15f-464f-bd9c-369efe9e5660",
       "adbed355-edcb-45f5-86d1-b7079b24b923",
       "item-1",
-      "de2e76e7-368f-4acf-ad07-cbbc804c4797"
+      "de2e76e7-368f-4acf-ad07-cbbc804c4797",
+      "ffe016dd-3970-45b1-a898-3e3651461058",
+      "e9637576-9917-4f30-b317-c155bd17757d",
+      "7be21bb4-9a97-4d92-a850-bb9fe4ef6673",
+      "28430088-5437-4272-ab34-70edfab1f354"
     ],
-    "started": [
-      "823615c7-a15f-464f-bd9c-369efe9e5660"
-    ]
+    "started": []
   }
 ]

--- a/client/src/components/RadarTracker.css
+++ b/client/src/components/RadarTracker.css
@@ -1,0 +1,53 @@
+.radar-wrapper {
+  margin-top: 0.5rem;
+  text-align: center;
+}
+
+.radar-wrapper h4 {
+  margin: 0 0 0.5rem 0;
+}
+
+.radar-carousel {
+  position: relative;
+  overflow: hidden;
+  height: 220px;
+}
+
+.radar-track {
+  display: flex;
+  height: 100%;
+  transition: transform 0.4s ease;
+}
+
+.radar-item {
+  flex: 0 0 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.radar-navs {
+  margin-top: 0.25rem;
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.radar-nav {
+  background: #008bd2;
+  color: #fff;
+  border: none;
+  padding: 4px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.radar-nav:hover {
+  background: #006fa1;
+}
+
+.radar-tip ul {
+  margin: 0;
+  padding-left: 1rem;
+}
+

--- a/client/src/components/RadarTracker.tsx
+++ b/client/src/components/RadarTracker.tsx
@@ -1,0 +1,80 @@
+import React, { useState } from 'react';
+import { RadarChart, PolarGrid, PolarAngleAxis, PolarRadiusAxis, Radar, Tooltip } from 'recharts';
+import { IModule, IProgress, IItem } from '../api/modules';
+import { flatten } from '../utils/items';
+import './RadarTracker.css';
+
+interface RadarTrackerProps {
+  modules: IModule[];
+  progress: IProgress[];
+  username: string;
+}
+
+export default function RadarTracker({ modules, progress, username }: RadarTrackerProps) {
+  const [idx, setIdx] = useState(0);
+
+  const userProg = progress.filter(p => p.username === username);
+
+  const prev = () => setIdx(i => (i - 1 + modules.length) % modules.length);
+  const next = () => setIdx(i => (i + 1) % modules.length);
+
+  const buildData = (mod: IModule) => {
+    const p = userProg.find(x => x.moduleId === mod.id);
+    return mod.items.map(item => {
+      const children = flatten(item.children ?? []);
+      const total = children.length || 1;
+      const visited = children.filter(ch => p?.visited.includes(ch.id)).length;
+      const percent = Math.round((visited / total) * 100);
+      return { subject: item.title, percent, item, progress: p };
+    });
+  };
+
+  const TooltipContent = ({ active, payload }: any) => {
+    if (active && payload && payload.length) {
+      const { item, progress: pr } = payload[0].payload as { item: IItem; progress?: IProgress };
+      const children = item.children ?? [];
+      return (
+        <div className="radar-tip">
+          <ul>
+            {children.map(ch => {
+              const status = pr?.visited.includes(ch.id)
+                ? '✅'
+                : pr?.started.includes(ch.id)
+                ? '🚧'
+                : '📍';
+              return <li key={ch.id}>{ch.title} {status}</li>;
+            })}
+          </ul>
+        </div>
+      );
+    }
+    return null;
+  };
+
+  return (
+    <div className="radar-wrapper">
+      <h4>{modules[idx]?.title}</h4>
+      <div className="radar-carousel">
+        <div className="radar-track" style={{ transform: `translateX(-${idx * 100}%)` }}>
+          {modules.map(m => (
+            <div className="radar-item" key={m.id}>
+              <RadarChart width={220} height={220} outerRadius={80} data={buildData(m)}>
+                <PolarGrid />
+                <PolarAngleAxis dataKey="subject" />
+                <PolarRadiusAxis angle={90} domain={[0, 100]} tick={false} />
+                <Radar dataKey="percent" fill="#008bd2" fillOpacity={0.6} />
+                <Tooltip content={<TooltipContent />} />
+              </RadarChart>
+            </div>
+          ))}
+        </div>
+      </div>
+      {modules.length > 1 && (
+        <div className="radar-navs">
+          <button className="radar-nav" onClick={prev}>←</button>
+          <button className="radar-nav" onClick={next}>→</button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/RadarTracker.tsx
+++ b/client/src/components/RadarTracker.tsx
@@ -51,6 +51,8 @@ export default function RadarTracker({ modules, progress, username }: RadarTrack
     return null;
   };
 
+  
+
   return (
     <div className="radar-wrapper">
       <h4>{modules[idx]?.title}</h4>
@@ -58,11 +60,11 @@ export default function RadarTracker({ modules, progress, username }: RadarTrack
         <div className="radar-track" style={{ transform: `translateX(-${idx * 100}%)` }}>
           {modules.map(m => (
             <div className="radar-item" key={m.id}>
-              <RadarChart width={220} height={220} outerRadius={80} data={buildData(m)}>
+              <RadarChart width={500} height={500} outerRadius={80} data={buildData(m)}>
                 <PolarGrid />
                 <PolarAngleAxis dataKey="subject" />
                 <PolarRadiusAxis angle={90} domain={[0, 100]} tick={false} />
-                <Radar dataKey="percent" fill="#008bd2" fillOpacity={0.6} />
+                <Radar dataKey="percent" fill='#ff5252' stroke='#ff5252' fillOpacity={0.6} />
                 <Tooltip content={<TooltipContent />} />
               </RadarChart>
             </div>

--- a/client/src/pages/ProgressPage.css
+++ b/client/src/pages/ProgressPage.css
@@ -72,3 +72,8 @@
   margin: 0;
   padding-left: 1.2rem;
 }
+
+/* zone du radar tracker */
+.progress_tracker {
+  text-align: center;
+}

--- a/client/src/pages/ProgressPage.tsx
+++ b/client/src/pages/ProgressPage.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '../context/AuthContext';
 import { IUser } from '../api/auth';
 import { IProgress, IModule, getModules } from '../api/modules';
 import ProgressBar from '../components/ProgressBar';
+import RadarTracker from '../components/RadarTracker';
 import { flatten } from '../utils/items';
 import './ProgressPage.css';
 
@@ -69,6 +70,7 @@ export default function ProgressPage() {
         </button>
       </div>
             {isOpen && (
+              <>
               <div className="stat_box">
                 <h3>En cours</h3>
                 {started.length === 0 ? (
@@ -79,6 +81,11 @@ export default function ProgressPage() {
                   </ul>
                 )}
               </div>
+              <div className="stat_box progress_tracker">
+                <h3>Progress Tracker</h3>
+                <RadarTracker modules={mods} progress={prog} username={c.username} />
+              </div>
+              </>
             )}
           </div>
         );


### PR DESCRIPTION
## Summary
- add `RadarTracker` component using a radar chart from Recharts
- style the new tracker
- show `Progress Tracker` frame under each user's current items list

## Testing
- `npm test --prefix client --silent` *(fails: No tests found)*