### PR TITLE
Add delete confirmation in ModuleEditor

### DIFF
--- a/client/src/components/ModuleEditor.css
+++ b/client/src/components/ModuleEditor.css
@@ -18,10 +18,14 @@
                                    display:inline-block; transition:background .15s; }
              .tree-scroll li>span:hover
       
-             .item-acts          { display:inline-flex; gap:4px; margin-left:6px; }
-             .item-acts button   { background:none; border:none; cursor:pointer; padding:0 2px;
-                                   color:#555; }
-             .item-acts button:hover { color:#000; }
+.item-acts          { display:inline-flex; gap:4px; margin-left:6px; }
+.item-acts button   { background:none; border:none; cursor:pointer; padding:0 2px;
+                                  color:#555; }
+.item-acts button:hover { color:#000; }
+
+.item-delete        { background:none; border:none; cursor:pointer; padding:0 2px;
+                                   color:#555; margin-right:6px; }
+.item-delete:hover  { color:#000; }
       
              /* ----------------- zone formulaire ----------------- */
              .editor             { flex:1; overflow-y:auto; padding:24px; }

--- a/client/src/components/ModuleEditor.tsx
+++ b/client/src/components/ModuleEditor.tsx
@@ -122,11 +122,18 @@ const ModuleEditor = forwardRef<ModuleEditorHandle, Props>(
                     }));
                   };
       
-                  const delItem = (id: string) =>
+                  const delItem = (id: string) => {
+                    if (
+                      !window.confirm(
+                        'Supprimer cet item ? Cette action est irréversible.'
+                      )
+                    )
+                      return;
                     setEdit((prev) => ({
                       ...prev,
                       items: filterTree(prev.items, (it) => it.id !== id),
                     }));
+                  };
       
                   const move = (id: string, dir: -1 | 1) => {
                     const reorder = (xs: IItem[]): IItem[] => {
@@ -189,13 +196,20 @@ const ModuleEditor = forwardRef<ModuleEditorHandle, Props>(
                     <ul>
                       {branch.map((it) => (
                         <li key={it.id} className={it.id === curId ? 'sel' : ''}>
+                          <button
+                            className="item-delete"
+                            onClick={() => delItem(it.id)}
+                            title="Supprimer"
+                          >
+                            🗑️
+                          </button>
+
                           <span onClick={() => setCurId(it.id)}>{it.title || '∅'}</span>
-      
+
                           <div className="item-acts">
                             <button onClick={() => addItem(it)} title="Ajouter">＋</button>
                             <button onClick={() => move(it.id, -1)} title="Monter">↑</button>
                             <button onClick={() => move(it.id, +1)} title="Descendre">↓</button>
-                            <button onClick={() => delItem(it.id)} title="Supprimer">🗑️</button>
                           </div>
       
                           {(it.children?.length ?? 0) > 0 && renderTree(it.children ?? [])}


### PR DESCRIPTION
## Summary
- confirm before deleting an item in ModuleEditor
- move trash icon before item title to reduce accidental clicks
- style new delete button

## Testing
- `npm --workspace client test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683d6a1674fc8323833e23beaa58782d