### PR TITLE
Fix manager dropdown in admin edit

### DIFF
--- a/client/src/pages/AdminDashboardPage.css
+++ b/client/src/pages/AdminDashboardPage.css
@@ -77,9 +77,18 @@
                background: #f5fbff;
              }
     
-             .admin-dashboard button {
-               background: none;
-               border: none;
-               cursor: pointer;
-               font-size: 1.1rem;
-             }
+.admin-dashboard button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.1rem;
+}
+
+/* form d'édition dans le tableau */
+.edit-form input,
+.edit-form select {
+  padding: .5rem;
+  margin-bottom: .25rem;
+  width: 100%;
+}
+.edit-form button { margin-right: .5rem; }


### PR DESCRIPTION
## Summary
- replace prompt-based edit with inline form
- fetch managers for dropdown selection
- style new edit form

## Testing
- `npx tsc -p client/tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_683d6d4f37288323a53e8133924277a2