### PR TITLE
Implement manager site requirement

### DIFF
--- a/backend/dist/routes/users.js
+++ b/backend/dist/routes/users.js
@@ -32,6 +32,8 @@ router.post('/', (req, res) => {
         return res.status(400).json({ error: 'Un manager ne peut avoir de managerId' });
     if (role === 'caf' && !managerId)
         return res.status(400).json({ error: 'managerId requis pour un CAF' });
+    if (role === 'manager' && !site)
+        return res.status(400).json({ error: 'site requis pour un manager' });
     const user = {
         id: Date.now().toString(),
         username,
@@ -71,7 +73,14 @@ router.patch('/:id', (req, res) => {
         if (list.some(u => u.username === data.username && u.id !== req.params.id))
             return res.status(409).json({ error: 'Nom déjà pris' });
     }
-    Object.assign(list[idx], data);
+    const updated = { ...list[idx], ...data };
+    if (updated.role === 'manager' && updated.managerId)
+        return res.status(400).json({ error: 'Un manager ne peut avoir de managerId' });
+    if (updated.role === 'caf' && !updated.managerId)
+        return res.status(400).json({ error: 'managerId requis pour un CAF' });
+    if (updated.role === 'manager' && !updated.site)
+        return res.status(400).json({ error: 'site requis pour un manager' });
+    Object.assign(list[idx], updated);
     (0, dataStore_1.write)(TABLE, list);
     const { password, ...clean } = list[idx];
     res.json(clean);

--- a/backend/src/data/users.json
+++ b/backend/src/data/users.json
@@ -53,7 +53,8 @@
     "id": "1747914779153",
     "username": "jonathan.candelier@alten.com",
     "password": "$2b$08$sK71pwta3R0rEpgI5eP1H.Rzkcw9B4gYHFCOJOw/7fckjjskBCpJu",
-    "role": "manager"
+    "role": "manager",
+    "site": "Nantes"
   },
   {
     "id": "1748425265715",

--- a/backend/src/models/IUser.ts
+++ b/backend/src/models/IUser.ts
@@ -7,7 +7,7 @@ export interface IUser {
     id:        string;
     username:  string;
     password:  string;
-    role:      Role;   // ← manager ajouté
-    site?:     string;           // pour les CAF
-    managerId?: string;          // CAF ➟ manager référent
+    role:      Role;                 // admin | manager | caf | user
+    site?:     string;               // site d'affectation (manager ou CAF)
+    managerId?: string;              // CAF ➟ manager référent
 }

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -34,6 +34,8 @@ if (role === 'manager' && managerId)
     return res.status(400).json({ error: 'Un manager ne peut avoir de managerId' });
 if (role === 'caf' && !managerId)
     return res.status(400).json({ error: 'managerId requis pour un CAF' });
+if (role === 'manager' && !site)
+    return res.status(400).json({ error: 'site requis pour un manager' });
 
 const user: IUser = {
     id: Date.now().toString(),
@@ -76,7 +78,15 @@ if (data.username) {
     return res.status(409).json({ error: 'Nom déjà pris' });
 }
 
-Object.assign(list[idx], data);
+const updated = { ...list[idx], ...data } as IUser;
+if (updated.role === 'manager' && updated.managerId)
+    return res.status(400).json({ error: 'Un manager ne peut avoir de managerId' });
+if (updated.role === 'caf' && !updated.managerId)
+    return res.status(400).json({ error: 'managerId requis pour un CAF' });
+if (updated.role === 'manager' && !updated.site)
+    return res.status(400).json({ error: 'site requis pour un manager' });
+
+Object.assign(list[idx], updated);
 write(TABLE, list);
 const { password, ...clean } = list[idx];
 res.json(clean);

--- a/client/src/pages/AdminDashboardPage.tsx
+++ b/client/src/pages/AdminDashboardPage.tsx
@@ -70,7 +70,7 @@ import { PieChart, Pie, Cell, Legend, ResponsiveContainer } from 'recharts';
       const body = {
         username: editUsername,
         role: editRole,
-        site: editRole === 'caf' ? editSite : undefined,
+        site: editRole === 'caf' || editRole === 'manager' ? editSite : undefined,
         managerId: editRole === 'caf' ? editManagerId : undefined,
       };
 
@@ -163,7 +163,7 @@ import { PieChart, Pie, Cell, Legend, ResponsiveContainer } from 'recharts';
                     </select>
                   </td>
                   <td>
-                    {editRole === 'caf' ? (
+                    {editRole === 'caf' || editRole === 'manager' ? (
                       <select value={editSite} onChange={e => setEditSite(e.target.value)}>
                         <option>Nantes</option>
                         <option>Montoir</option>

--- a/client/src/pages/RegisterUserPage.tsx
+++ b/client/src/pages/RegisterUserPage.tsx
@@ -50,7 +50,7 @@ export default function RegisterUserPage() {
         username,
         password,
         role,
-        site: role === 'caf' ? site : undefined,
+        site: role === 'caf' || role === 'manager' ? site : undefined,
         managerId: role === 'caf'
           ? (user?.role === 'manager' ? user.id : managerId)
           : undefined,
@@ -85,7 +85,7 @@ export default function RegisterUserPage() {
           </select>
         </label>
 
-        {role === 'caf' && (
+        {(role === 'caf' || role === 'manager') && (
           <>
             <label>Site
               <select value={site} onChange={e=>setSite(e.target.value)}>
@@ -95,7 +95,7 @@ export default function RegisterUserPage() {
             </label>
 
             {/* sélection manager : visible seulement pour l’admin */}
-            {user?.role === 'admin' && (
+            {role === 'caf' && user?.role === 'admin' && (
               <label>Manager
                 <select
                   value={managerId}


### PR DESCRIPTION
## Summary
- require `site` for manager accounts in user creation and update
- display site selector when managers are edited or created
- update user sample data to include missing manager site

## Testing
- `npm --workspace backend run build`
- `npx tsc -p client/tsconfig.json --noEmit`
- `npx tsc -p backend/tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_683d70353f3083238166ab3218c27339