### PR TITLE
Implement multi-manager support

### DIFF
--- a/backend/dist/index.js
+++ b/backend/dist/index.js
@@ -15,6 +15,7 @@ const modules_1 = __importDefault(require("./routes/modules"));
 const notifications_1 = __importDefault(require("./routes/notifications"));
 const progress_1 = __importDefault(require("./routes/progress"));
 const tickets_1 = __importDefault(require("./routes/tickets"));
+const checklist_1 = __importDefault(require("./routes/checklist"));
 const app = (0, express_1.default)();
 const PORT = process.env.PORT || 5000;
 app.use((0, cors_1.default)());
@@ -25,6 +26,7 @@ app.use('/api/modules', modules_1.default);
 app.use('/api/notifications', notifications_1.default);
 app.use('/api/progress', progress_1.default);
 app.use('/api/tickets', tickets_1.default);
+app.use('/api/checklist-url', checklist_1.default);
 app.get('/', (_req, res) => {
     res.send('🚀 Backend TS démarré !');
 });

--- a/backend/dist/routes/auth.js
+++ b/backend/dist/routes/auth.js
@@ -27,12 +27,12 @@ router.post('/login', (req, res) => {
     });
     if (!user)
         return res.status(401).json({ error: 'Identifiants invalides' });
-    const { id, role, site } = user;
-    res.json({ id, username, role, site });
+    const { id, role, site, managerIds } = user;
+    res.json({ id, username, role, site, managerIds });
 });
 /* ───────────────────────── REGISTER ────────────────────── */
 router.post('/register', (req, res) => {
-    const { username, password, role, site, managerId } = req.body;
+    const { username, password, role, site, managerIds } = req.body;
     if (!username || !password || !role)
         return res.status(400).json({ error: 'Champs manquants' });
     if (!mailRx.test(username))
@@ -47,11 +47,11 @@ router.post('/register', (req, res) => {
         password: bcrypt_1.default.hashSync(password, 8),
         role,
         site,
-        managerId,
+        managerIds,
     };
     users.push(newUser);
     (0, dataStore_1.write)(USERS, users);
-    res.status(201).json({ id, username, role, site, managerId });
+    res.status(201).json({ id, username, role, site, managerIds });
 });
 /* ───────────────────────── FORGOT PWD ───────────────────── */
 router.post('/forgot', (req, res) => {
@@ -67,8 +67,9 @@ router.post('/forgot', (req, res) => {
     const admins = users
         .filter(u => u.role === 'admin' && mailRx.test(u.username))
         .map(u => u.username);
-    const managerMail = user.managerId
-        ? users.find(u => u.id === user.managerId)?.username
+    const firstManager = user.managerIds ? user.managerIds[0] : undefined;
+    const managerMail = firstManager
+        ? users.find(u => u.id === firstManager)?.username
         : undefined;
     const to = [
         ...admins,

--- a/backend/dist/routes/modules.js
+++ b/backend/dist/routes/modules.js
@@ -4,19 +4,27 @@ const express_1 = require("express");
 const dataStore_1 = require("../config/dataStore");
 const router = (0, express_1.Router)();
 const TABLE = 'modules';
-/* util ------------------------------------------------------------------ */
-function load() { return (0, dataStore_1.read)(TABLE); }
-function save(list) { (0, dataStore_1.write)(TABLE, list); }
-function byId(id, list = load()) { return list.find(m => m.id === id); }
-function idx(id, list = load()) { return list.findIndex(m => m.id === id); }
-/* GET /api/modules ------------------------------------------------------- */
+// ----- utilitaires -----
+function load() {
+    return (0, dataStore_1.read)(TABLE);
+}
+function save(list) {
+    (0, dataStore_1.write)(TABLE, list);
+}
+function byId(id, list = load()) {
+    return list.find((m) => m.id === id);
+}
+function idx(id, list = load()) {
+    return list.findIndex((m) => m.id === id);
+}
+// GET /api/modules
 router.get('/', (_req, res) => res.json(load()));
-/* GET /api/modules/:id --------------------------------------------------- */
+// GET /api/modules/:id
 router.get('/:id', (req, res) => {
     const mod = byId(req.params.id);
-    mod ? res.json(mod) : res.status(404).json({ error: 'Module non trouvé' });
+    return mod ? res.json(mod) : res.status(404).json({ error: 'Module non trouvé' });
 });
-/* POST /api/modules  (création) ----------------------------------------- */
+// POST /api/modules
 router.post('/', (req, res) => {
     const list = load();
     const id = Date.now().toString();
@@ -31,7 +39,7 @@ router.post('/', (req, res) => {
     save(list);
     res.status(201).json(mod);
 });
-/* PUT /api/modules/:id  (remplacement intégral) ------------------------- */
+// PUT /api/modules/:id
 router.put('/:id', (req, res) => {
     const list = load();
     const index = idx(req.params.id, list);
@@ -41,7 +49,7 @@ router.put('/:id', (req, res) => {
     save(list);
     res.json(list[index]);
 });
-/* PATCH /api/modules/:id  (MAJ partielle) ------------------------------- */
+// PATCH /api/modules/:id
 router.patch('/:id', (req, res) => {
     const list = load();
     const mod = byId(req.params.id, list);
@@ -51,7 +59,7 @@ router.patch('/:id', (req, res) => {
     save(list);
     res.json(mod);
 });
-/* DELETE /api/modules/:id ----------------------------------------------- */
+// DELETE /api/modules/:id
 router.delete('/:id', (req, res) => {
     const list = load();
     const index = idx(req.params.id, list);

--- a/backend/dist/routes/progress.js
+++ b/backend/dist/routes/progress.js
@@ -4,33 +4,44 @@ const express_1 = require("express");
 const dataStore_1 = require("../config/dataStore");
 const router = (0, express_1.Router)();
 const TABLE = 'progress';
-/* GET /api/progress/:username   – lecture complète d’un CAF */
+// GET /api/progress/:username – lecture complète d’un CAF
 router.get('/:username', (req, res) => {
-    const rows = (0, dataStore_1.read)(TABLE).filter(p => p.username === req.params.username);
+    const rows = (0, dataStore_1.read)(TABLE).filter((p) => p.username === req.params.username);
     res.json(rows);
 });
-/* PATCH /api/progress   body:{ username,moduleId,visited } – MAJ 1 module */
+// PATCH /api/progress – MAJ d'un module
 router.patch('/', (req, res) => {
-    const { username, moduleId, visited } = req.body;
-    if (!username || !moduleId)
+    const { username, moduleId, visited = [], started = [], needValidation = [], } = req.body;
+    if (!username || !moduleId) {
         return res.status(400).json({ error: 'Données manquantes' });
+    }
+    const uniqVisited = Array.from(new Set(visited));
+    const uniqNeedVal = Array.from(new Set(needValidation)).filter((id) => !uniqVisited.includes(id));
+    const uniqStarted = Array.from(new Set(started))
+        .filter((id) => !uniqVisited.includes(id) && !uniqNeedVal.includes(id));
     const list = (0, dataStore_1.read)(TABLE);
-    const idx = list.findIndex(p => p.username === username && p.moduleId === moduleId);
-    if (idx === -1)
-        list.push({ username, moduleId, visited });
-    else
-        list[idx].visited = visited;
+    const idx = list.findIndex((p) => p.username === username && p.moduleId === moduleId);
+    if (idx === -1) {
+        list.push({ username, moduleId, visited: uniqVisited, started: uniqStarted, needValidation: uniqNeedVal });
+    }
+    else {
+        list[idx].visited = uniqVisited;
+        list[idx].started = uniqStarted;
+        list[idx].needValidation = uniqNeedVal;
+    }
     (0, dataStore_1.write)(TABLE, list);
     res.json({ ok: true });
 });
-/* GET /api/progress?managerId=… – progression de tous les CAF d’un manager */
+// GET /api/progress?managerId=… – progression de tous les CAF d’un manager
 router.get('/', (req, res) => {
     const { managerId } = req.query;
     const rows = (0, dataStore_1.read)(TABLE);
     const users = (0, dataStore_1.read)('users');
     if (managerId) {
-        const cafIds = users.filter(u => u.managerId === managerId).map(u => u.username);
-        return res.json(rows.filter(r => cafIds.includes(r.username)));
+        const cafIds = users
+            .filter((u) => u.managerIds?.includes(managerId))
+            .map((u) => u.username);
+        return res.json(rows.filter((r) => cafIds.includes(r.username)));
     }
     res.json(rows);
 });

--- a/backend/dist/routes/tickets.js
+++ b/backend/dist/routes/tickets.js
@@ -27,7 +27,7 @@ router.post('/', (req, res) => {
     const ticket = {
         id: Date.now().toString(),
         username,
-        managerId: author?.managerId,
+        managerId: author?.managerIds?.[0],
         target: target,
         category,
         priority: priority || 'normal',
@@ -89,8 +89,13 @@ router.get('/:id/export', (req, res) => {
     res.send(JSON.stringify(ticket, null, 2));
 });
 router.patch('/:id', (req, res) => {
-    const { status, archived } = req.body;
-    if (status === undefined && archived === undefined)
+    const { status, archived, title, message, category, priority, } = req.body;
+    if (status === undefined &&
+        archived === undefined &&
+        title === undefined &&
+        message === undefined &&
+        category === undefined &&
+        priority === undefined)
         return res.status(400).json({ error: 'Données manquantes' });
     const list = load();
     const idx = list.findIndex(t => t.id === req.params.id);
@@ -100,6 +105,14 @@ router.patch('/:id', (req, res) => {
         list[idx].status = status;
     if (archived !== undefined)
         list[idx].archived = archived;
+    if (title !== undefined)
+        list[idx].title = title;
+    if (message !== undefined)
+        list[idx].message = message;
+    if (category !== undefined)
+        list[idx].category = category;
+    if (priority !== undefined)
+        list[idx].priority = priority;
     save(list);
     const ticket = list[idx];
     const to = mailRx.test(ticket.username) ? [ticket.username] : [];

--- a/backend/src/data/users.json
+++ b/backend/src/data/users.json
@@ -5,7 +5,7 @@
     "password": "$2b$08$S1UuW2Cv98yFwiT7HruPxOC/qxloCEgDmbQHKozx0ZOXwQrfpUypq",
     "role": "caf",
     "site": "Nantes",
-    "managerId": "1747838393929"
+    "managerIds": ["1747838393929"]
   },
   {
     "id": "1746634331825",
@@ -20,7 +20,7 @@
     "password": "$2b$08$6Qoxb8fbAOIdAoSCA4znXe6Q/oRZhG4b3jQRhz9bLnXvrC/ie9f7y",
     "role": "caf",
     "site": "Nantes",
-    "managerId": "1747838393929"
+    "managerIds": ["1747838393929"]
   },
   {
     "id": "1747039012242",
@@ -40,7 +40,7 @@
     "password": "$2b$08$jx1eTFqpRuWka0b3U0Rsx.T.x6VZeJ.ezsJqzckbwyNcyWzLH8x/.",
     "role": "caf",
     "site": "Montoir",
-    "managerId": "1746634331825"
+    "managerIds": ["1746634331825"]
   },
   {
     "id": "1747838393929",
@@ -53,7 +53,8 @@
     "id": "1747914779153",
     "username": "jonathan.candelier@alten.com",
     "password": "$2b$08$sK71pwta3R0rEpgI5eP1H.Rzkcw9B4gYHFCOJOw/7fckjjskBCpJu",
-    "role": "manager"
+    "role": "manager",
+    "site": "Nantes"
   },
   {
     "id": "1748425265715",
@@ -61,7 +62,7 @@
     "password": "$2b$08$2gXy/vGhv87SWkayLneAPOq8cCUUbvooxNSpPGXZPHzgD4ML0fbua",
     "role": "caf",
     "site": "Nantes",
-    "managerId": "1747838393929"
+    "managerIds": ["1747838393929"]
   },
   {
     "id": "1748425281829",
@@ -69,6 +70,6 @@
     "password": "$2b$08$M5ic/74.EmJHQ1BT5t/3Ke/cJSuRMUX7NTumQGXvnI4tg8rDl6j1W",
     "role": "caf",
     "site": "Montoir",
-    "managerId": "1747838393929"
+    "managerIds": ["1747838393929"]
   }
 ]

--- a/backend/src/models/IUser.ts
+++ b/backend/src/models/IUser.ts
@@ -7,7 +7,7 @@ export interface IUser {
     id:        string;
     username:  string;
     password:  string;
-    role:      Role;   // ← manager ajouté
-    site?:     string;           // pour les CAF
-    managerId?: string;          // CAF ➟ manager référent
+    role:      Role;                 // admin | manager | caf | user
+    site?:     string;               // site d'affectation (manager ou CAF)
+    managerIds?: string[];           // CAF ➟ managers référents
 }

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -28,13 +28,13 @@ router.post('/login', (req, res) => {
 
     if (!user) return res.status(401).json({ error: 'Identifiants invalides' });
 
-    const { id, role, site } = user;
-    res.json({ id, username, role, site });
+    const { id, role, site, managerIds } = user;
+    res.json({ id, username, role, site, managerIds });
 });
 
 /* ───────────────────────── REGISTER ────────────────────── */
 router.post('/register', (req, res) => {
-    const { username, password, role, site, managerId } = req.body as Partial<IUser>;
+    const { username, password, role, site, managerIds } = req.body as Partial<IUser>;
 
     if (!username || !password || !role)
     return res.status(400).json({ error: 'Champs manquants' });
@@ -52,12 +52,12 @@ router.post('/register', (req, res) => {
     password: bcrypt.hashSync(password, 8),
     role,
     site,
-    managerId,
+    managerIds,
     } as IUser;
 
     users.push(newUser);
     write(USERS, users);
-    res.status(201).json({ id, username, role, site, managerId });
+    res.status(201).json({ id, username, role, site, managerIds });
 });
 
 /* ───────────────────────── FORGOT PWD ───────────────────── */
@@ -75,8 +75,9 @@ router.post('/forgot', (req, res) => {
     const admins      = users
       .filter(u => u.role === 'admin' && mailRx.test(u.username))
       .map(u => u.username);
-    const managerMail = user.managerId
-      ? users.find(u => u.id === user.managerId)?.username
+    const firstManager = user.managerIds ? user.managerIds[0] : undefined;
+    const managerMail = firstManager
+      ? users.find(u => u.id === firstManager)?.username
       : undefined;
 
     const to = [

--- a/backend/src/routes/progress.ts
+++ b/backend/src/routes/progress.ts
@@ -53,7 +53,9 @@ router.get('/', (req, res) => {
   const users = read<IUser>('users');
 
   if (managerId) {
-    const cafIds = users.filter((u) => u.managerId === managerId).map((u) => u.username);
+    const cafIds = users
+      .filter((u) => u.managerIds?.includes(managerId))
+      .map((u) => u.username);
     return res.json(rows.filter((r) => cafIds.includes(r.username)));
   }
   res.json(rows);

--- a/backend/src/routes/tickets.ts
+++ b/backend/src/routes/tickets.ts
@@ -38,7 +38,7 @@ router.post('/', (req, res) => {
   const ticket: ITicket = {
     id: Date.now().toString(),
     username,
-    managerId: author?.managerId,
+    managerId: author?.managerIds?.[0],
     target: target as any,
     category,
     priority: (priority as TicketPriority) || 'normal',

--- a/client/src/api/auth.ts
+++ b/client/src/api/auth.ts
@@ -7,5 +7,5 @@
                username:  string;
                role:       Role;   // ← manager ajouté
                site?:     string;
-               managerId?: string;
+               managerIds?: string[];
              }

--- a/client/src/context/AuthContext.tsx
+++ b/client/src/context/AuthContext.tsx
@@ -9,7 +9,7 @@ import React, {
         username:   string;
         role:       'admin' | 'manager' | 'caf' | 'user';  // ← manager
         site?:      string;
-        managerId?: string;
+        managerIds?: string[];
       }
     
     

--- a/client/src/pages/AdminDashboardPage.tsx
+++ b/client/src/pages/AdminDashboardPage.tsx
@@ -17,7 +17,7 @@ import { PieChart, Pie, Cell, Legend, ResponsiveContainer } from 'recharts';
    const [editUsername, setEditUsername] = useState('');
    const [editRole, setEditRole] = useState<Role>('caf');
    const [editSite, setEditSite] = useState('Nantes');
-   const [editManagerId, setEditManagerId] = useState('');
+   const [editManagerIds, setEditManagerIds] = useState<string[]>([]);
 
    const mailRx = /^[a-z0-9]+(\.[a-z0-9]+)?@alten\.com$/i;
 
@@ -61,7 +61,7 @@ import { PieChart, Pie, Cell, Legend, ResponsiveContainer } from 'recharts';
       setEditUsername(u.username);
       setEditRole(u.role);
       setEditSite(u.site || 'Nantes');
-      setEditManagerId(u.managerId || '');
+      setEditManagerIds(u.managerIds || []);
     };
 
     const saveEdit = async (id: string) => {
@@ -70,8 +70,8 @@ import { PieChart, Pie, Cell, Legend, ResponsiveContainer } from 'recharts';
       const body = {
         username: editUsername,
         role: editRole,
-        site: editRole === 'caf' ? editSite : undefined,
-        managerId: editRole === 'caf' ? editManagerId : undefined,
+        site: editRole === 'caf' || editRole === 'manager' ? editSite : undefined,
+        managerIds: editRole === 'caf' ? editManagerIds : undefined,
       };
 
       const res = await fetch(`/api/users/${id}`, {
@@ -163,7 +163,7 @@ import { PieChart, Pie, Cell, Legend, ResponsiveContainer } from 'recharts';
                     </select>
                   </td>
                   <td>
-                    {editRole === 'caf' ? (
+                    {editRole === 'caf' || editRole === 'manager' ? (
                       <select value={editSite} onChange={e => setEditSite(e.target.value)}>
                         <option>Nantes</option>
                         <option>Montoir</option>
@@ -172,8 +172,13 @@ import { PieChart, Pie, Cell, Legend, ResponsiveContainer } from 'recharts';
                   </td>
                   <td>
                     {editRole === 'caf' ? (
-                      <select value={editManagerId} onChange={e => setEditManagerId(e.target.value)}>
-                        <option value="">— choisir —</option>
+                      <select
+                        multiple
+                        value={editManagerIds}
+                        onChange={e =>
+                          setEditManagerIds(Array.from(e.target.selectedOptions).map(o => o.value))
+                        }
+                      >
                         {managers.map(m => (
                           <option key={m.id} value={m.id}>{m.username}</option>
                         ))}
@@ -190,7 +195,13 @@ import { PieChart, Pie, Cell, Legend, ResponsiveContainer } from 'recharts';
                   <td>{u.username}</td>
                   <td>{u.role}</td>
                   <td>{u.site ?? '—'}</td>
-                  <td>{u.managerId ? users.find(m => m.id === u.managerId)?.username ?? u.managerId : '—'}</td>
+                  <td>
+                    {u.managerIds && u.managerIds.length > 0
+                      ? u.managerIds
+                          .map(id => users.find(m => m.id === id)?.username || id)
+                          .join(', ')
+                      : '—'}
+                  </td>
                   <td style={{ whiteSpace: 'nowrap' }}>
                     <button onClick={() => startEdit(u)} title="Modifier">✏️</button>{' '}
                     <button onClick={() => resetPwd(u.id)} title="Réinit. MDP">🔑</button>{' '}


### PR DESCRIPTION
## Summary
- allow CAF users to reference several managers
- require `managerIds` during user creation & updates
- adjust admin and register forms for multi-manager selection
- update progress filtering logic

## Testing
- `npm --workspace backend run build`
- `npx tsc -p client/tsconfig.json --noEmit`
- `npx tsc -p backend/tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_683d70353f3083238166ab3218c27339