### PR TITLE
Implement manager site requirement

### DIFF
--- a/backend/dist/routes/progress.js
+++ b/backend/dist/routes/progress.js
@@ -4,32 +4,41 @@ const express_1 = require("express");
 const dataStore_1 = require("../config/dataStore");
 const router = (0, express_1.Router)();
 const TABLE = 'progress';
-/* GET /api/progress/:username   – lecture complète d’un CAF */
+// GET /api/progress/:username – lecture complète d’un CAF
 router.get('/:username', (req, res) => {
-    const rows = (0, dataStore_1.read)(TABLE).filter(p => p.username === req.params.username);
+    const rows = (0, dataStore_1.read)(TABLE).filter((p) => p.username === req.params.username);
     res.json(rows);
 });
-/* PATCH /api/progress   body:{ username,moduleId,visited } – MAJ 1 module */
+// PATCH /api/progress – MAJ d'un module
 router.patch('/', (req, res) => {
-    const { username, moduleId, visited } = req.body;
-    if (!username || !moduleId)
+    const { username, moduleId, visited = [], started = [], needValidation = [], } = req.body;
+    if (!username || !moduleId) {
         return res.status(400).json({ error: 'Données manquantes' });
+    }
+    const uniqVisited = Array.from(new Set(visited));
+    const uniqNeedVal = Array.from(new Set(needValidation)).filter((id) => !uniqVisited.includes(id));
+    const uniqStarted = Array.from(new Set(started))
+        .filter((id) => !uniqVisited.includes(id) && !uniqNeedVal.includes(id));
     const list = (0, dataStore_1.read)(TABLE);
-    const idx = list.findIndex(p => p.username === username && p.moduleId === moduleId);
-    if (idx === -1)
-        list.push({ username, moduleId, visited });
-    else
-        list[idx].visited = visited;
+    const idx = list.findIndex((p) => p.username === username && p.moduleId === moduleId);
+    if (idx === -1) {
+        list.push({ username, moduleId, visited: uniqVisited, started: uniqStarted, needValidation: uniqNeedVal });
+    }
+    else {
+        list[idx].visited = uniqVisited;
+        list[idx].started = uniqStarted;
+        list[idx].needValidation = uniqNeedVal;
+    }
     (0, dataStore_1.write)(TABLE, list);
     res.json({ ok: true });
 });
-/* GET /api/progress?managerId=… – progression de tous les CAF d’un manager */
+// GET /api/progress?managerId=… – progression de tous les CAF d’un manager
 router.get('/', (req, res) => {
     const { managerId } = req.query;
     const rows = (0, dataStore_1.read)(TABLE);
     const users = (0, dataStore_1.read)('users');
     if (managerId) {
-        const cafIds = users.filter(u => u.managerId === managerId).map(u => u.username);
+        const cafIds = users.filter(u => u.managerIds?.includes(managerId)).map(u => u.username);
         return res.json(rows.filter(r => cafIds.includes(r.username)));
     }
     res.json(rows);

--- a/backend/dist/routes/tickets.js
+++ b/backend/dist/routes/tickets.js
@@ -27,7 +27,7 @@ router.post('/', (req, res) => {
     const ticket = {
         id: Date.now().toString(),
         username,
-        managerId: author?.managerId,
+        managerId: author?.managerIds ? author.managerIds[0] : undefined,
         target: target,
         category,
         priority: priority || 'normal',
@@ -89,8 +89,13 @@ router.get('/:id/export', (req, res) => {
     res.send(JSON.stringify(ticket, null, 2));
 });
 router.patch('/:id', (req, res) => {
-    const { status, archived } = req.body;
-    if (status === undefined && archived === undefined)
+    const { status, archived, title, message, category, priority, } = req.body;
+    if (status === undefined &&
+        archived === undefined &&
+        title === undefined &&
+        message === undefined &&
+        category === undefined &&
+        priority === undefined)
         return res.status(400).json({ error: 'Données manquantes' });
     const list = load();
     const idx = list.findIndex(t => t.id === req.params.id);
@@ -100,6 +105,14 @@ router.patch('/:id', (req, res) => {
         list[idx].status = status;
     if (archived !== undefined)
         list[idx].archived = archived;
+    if (title !== undefined)
+        list[idx].title = title;
+    if (message !== undefined)
+        list[idx].message = message;
+    if (category !== undefined)
+        list[idx].category = category;
+    if (priority !== undefined)
+        list[idx].priority = priority;
     save(list);
     const ticket = list[idx];
     const to = mailRx.test(ticket.username) ? [ticket.username] : [];

--- a/backend/dist/routes/users.js
+++ b/backend/dist/routes/users.js
@@ -15,12 +15,12 @@ router.get('/', (_req, res) => {
     const { managerId } = _req.query;
     let list = (0, dataStore_1.read)(TABLE);
     if (managerId)
-        list = list.filter(u => u.managerId === managerId);
+        list = list.filter(u => u.managerIds?.includes(managerId));
     res.json(list.map(({ password, ...u }) => u));
 });
 /* ───────────── POST création ─────────────────── */
 router.post('/', (req, res) => {
-    const { username, password, role, site, managerId } = req.body;
+    const { username, password, role, site, managerIds, sites } = req.body;
     if (!username || !password || !role)
         return res.status(400).json({ error: 'Champs manquants' });
     if (!mailRx.test(username))
@@ -28,17 +28,20 @@ router.post('/', (req, res) => {
     const list = (0, dataStore_1.read)(TABLE);
     if (list.some(u => u.username === username))
         return res.status(409).json({ error: 'Nom déjà pris' });
-    if (role === 'manager' && managerId)
-        return res.status(400).json({ error: 'Un manager ne peut avoir de managerId' });
-    if (role === 'caf' && !managerId)
-        return res.status(400).json({ error: 'managerId requis pour un CAF' });
+    if (role === 'manager' && managerIds?.length)
+        return res.status(400).json({ error: 'Un manager ne peut avoir de managerIds' });
+    if (role === 'caf' && (!managerIds || managerIds.length === 0))
+        return res.status(400).json({ error: 'managerIds requis pour un CAF' });
+    if (role === 'manager' && (!sites || sites.length === 0))
+        return res.status(400).json({ error: 'sites requis pour un manager' });
     const user = {
         id: Date.now().toString(),
         username,
         password: hash(password),
         role: role,
-        site,
-        managerId,
+        site: role === 'caf' ? site : undefined,
+        managerIds: role === 'caf' ? managerIds : undefined,
+        sites: role === 'manager' ? sites : undefined,
     };
     list.push(user);
     (0, dataStore_1.write)(TABLE, list);
@@ -71,7 +74,14 @@ router.patch('/:id', (req, res) => {
         if (list.some(u => u.username === data.username && u.id !== req.params.id))
             return res.status(409).json({ error: 'Nom déjà pris' });
     }
-    Object.assign(list[idx], data);
+    const updated = { ...list[idx], ...data };
+    if (updated.role === 'manager' && updated.managerIds?.length)
+        return res.status(400).json({ error: 'Un manager ne peut avoir de managerIds' });
+    if (updated.role === 'caf' && (!updated.managerIds || updated.managerIds.length === 0))
+        return res.status(400).json({ error: 'managerIds requis pour un CAF' });
+    if (updated.role === 'manager' && (!updated.sites || updated.sites.length === 0))
+        return res.status(400).json({ error: 'sites requis pour un manager' });
+    Object.assign(list[idx], updated);
     (0, dataStore_1.write)(TABLE, list);
     const { password, ...clean } = list[idx];
     res.json(clean);

--- a/backend/src/data/users.json
+++ b/backend/src/data/users.json
@@ -5,14 +5,14 @@
     "password": "$2b$08$S1UuW2Cv98yFwiT7HruPxOC/qxloCEgDmbQHKozx0ZOXwQrfpUypq",
     "role": "caf",
     "site": "Nantes",
-    "managerId": "1747838393929"
+    "managerIds": ["1747838393929"]
   },
   {
     "id": "1746634331825",
     "username": "dylan",
     "password": "$2b$08$d9wiHryFBkzbJaLoJq9FWONXgLz.X1GChx4CYJyx5G3zpd12yPpKi",
     "role": "manager",
-    "site": "Nantes"
+    "sites": ["Nantes"]
   },
   {
     "id": "1746634829314",
@@ -20,7 +20,7 @@
     "password": "$2b$08$6Qoxb8fbAOIdAoSCA4znXe6Q/oRZhG4b3jQRhz9bLnXvrC/ie9f7y",
     "role": "caf",
     "site": "Nantes",
-    "managerId": "1747838393929"
+    "managerIds": ["1747838393929"]
   },
   {
     "id": "1747039012242",
@@ -40,20 +40,21 @@
     "password": "$2b$08$jx1eTFqpRuWka0b3U0Rsx.T.x6VZeJ.ezsJqzckbwyNcyWzLH8x/.",
     "role": "caf",
     "site": "Montoir",
-    "managerId": "1746634331825"
+    "managerIds": ["1746634331825"]
   },
   {
     "id": "1747838393929",
     "username": "camile.briard@alten.com",
     "password": "$2b$08$4clko9P2EA/CR4iujAzuquIRxCZcK0mdaCyZ3DbUFenVY.AoQYVsa",
     "role": "manager",
-    "site": "Nantes"
+    "sites": ["Nantes"]
   },
   {
     "id": "1747914779153",
     "username": "jonathan.candelier@alten.com",
     "password": "$2b$08$sK71pwta3R0rEpgI5eP1H.Rzkcw9B4gYHFCOJOw/7fckjjskBCpJu",
-    "role": "manager"
+    "role": "manager",
+    "sites": ["Nantes"]
   },
   {
     "id": "1748425265715",
@@ -61,7 +62,7 @@
     "password": "$2b$08$2gXy/vGhv87SWkayLneAPOq8cCUUbvooxNSpPGXZPHzgD4ML0fbua",
     "role": "caf",
     "site": "Nantes",
-    "managerId": "1747838393929"
+    "managerIds": ["1747838393929"]
   },
   {
     "id": "1748425281829",
@@ -69,6 +70,6 @@
     "password": "$2b$08$M5ic/74.EmJHQ1BT5t/3Ke/cJSuRMUX7NTumQGXvnI4tg8rDl6j1W",
     "role": "caf",
     "site": "Montoir",
-    "managerId": "1747838393929"
+    "managerIds": ["1747838393929"]
   }
 ]

--- a/backend/src/models/IUser.ts
+++ b/backend/src/models/IUser.ts
@@ -7,7 +7,12 @@ export interface IUser {
     id:        string;
     username:  string;
     password:  string;
-    role:      Role;   // ← manager ajouté
-    site?:     string;           // pour les CAF
-    managerId?: string;          // CAF ➟ manager référent
+    role:      Role;                 // admin | manager | caf | user
+
+    // ---- CAF fields ----
+    site?:        string;           // site d'affectation du CAF
+    managerIds?:  string[];         // CAF → plusieurs managers référents
+
+    // ---- manager fields ----
+    sites?:       string[];         // manager en charge de plusieurs sites
 }

--- a/backend/src/routes/progress.ts
+++ b/backend/src/routes/progress.ts
@@ -53,8 +53,8 @@ router.get('/', (req, res) => {
   const users = read<IUser>('users');
 
   if (managerId) {
-    const cafIds = users.filter((u) => u.managerId === managerId).map((u) => u.username);
-    return res.json(rows.filter((r) => cafIds.includes(r.username)));
+    const cafIds = users.filter(u => u.managerIds?.includes(managerId)).map(u => u.username);
+    return res.json(rows.filter(r => cafIds.includes(r.username)));
   }
   res.json(rows);
 });

--- a/backend/src/routes/tickets.ts
+++ b/backend/src/routes/tickets.ts
@@ -38,7 +38,7 @@ router.post('/', (req, res) => {
   const ticket: ITicket = {
     id: Date.now().toString(),
     username,
-    managerId: author?.managerId,
+    managerId: author?.managerIds ? author.managerIds[0] : undefined,
     target: target as any,
     category,
     priority: (priority as TicketPriority) || 'normal',

--- a/client/src/api/auth.ts
+++ b/client/src/api/auth.ts
@@ -2,10 +2,15 @@
       
              export type Role = 'admin' | 'manager' | 'caf' | 'user';
       
-             export interface IUser {
-               id:        string;
-               username:  string;
-               role:       Role;   // ← manager ajouté
-               site?:     string;
-               managerId?: string;
-             }
+export interface IUser {
+  id:        string;
+  username:  string;
+  role:       Role;
+
+  // CAF fields
+  site?:        string;
+  managerIds?:  string[];
+
+  // manager fields
+  sites?:       string[];
+}


### PR DESCRIPTION
## Summary
- support multiple sites for managers with `sites` field
- allow CAF accounts to link multiple managers via `managerIds`
- update user validations and routes for arrays
- adapt registration and admin pages to use checkbox selections
- regenerate compiled backend files

## Testing
- `npm --workspace backend run build`
- `npx tsc -p client/tsconfig.json --noEmit`
- `npx tsc -p backend/tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_683d70353f3083238166ab3218c27339