### PR TITLE
Add color code for module editor profiles

### DIFF
--- a/client/src/components/ModuleEditor.css
+++ b/client/src/components/ModuleEditor.css
@@ -17,6 +17,11 @@
              .tree-scroll li>span{ cursor:pointer; padding:2px 4px; border-radius:4px;
                                    display:inline-block; transition:background .15s; }
              .tree-scroll li>span:hover
+
+             /* codes couleur pour les profils */
+             .tree-scroll li.prof-nantes>span{ border-left:4px solid #e67e22; padding-left:4px; }
+             .tree-scroll li.prof-montoir>span{ border-left:4px solid #2ecc71; padding-left:4px; }
+             .tree-scroll li.prof-both>span   { border-left:4px solid #9b59b6; padding-left:4px; }
       
 .item-acts          { display:inline-flex; gap:4px; margin-left:6px; }
 .item-acts button   { background:none; border:none; cursor:pointer; padding:0 2px;

--- a/client/src/components/ModuleEditor.tsx
+++ b/client/src/components/ModuleEditor.tsx
@@ -194,8 +194,14 @@ const ModuleEditor = forwardRef<ModuleEditorHandle, Props>(
                   /* rendu récursif de l’arbre ------------------------------ */
                   const renderTree = (branch: IItem[]) => (
                     <ul>
-                      {branch.map((it) => (
-                        <li key={it.id} className={it.id === curId ? 'sel' : ''}>
+                      {branch.map((it) => {
+                        const p = new Set(it.profiles ?? []);
+                        let profClass = '';
+                        if (p.has('Nantes') && p.has('Montoir')) profClass = 'prof-both';
+                        else if (p.has('Nantes')) profClass = 'prof-nantes';
+                        else if (p.has('Montoir')) profClass = 'prof-montoir';
+                        return (
+                        <li key={it.id} className={`${it.id === curId ? 'sel' : ''} ${profClass}`}>
                           <button
                             className="item-delete"
                             onClick={() => delItem(it.id)}
@@ -211,10 +217,10 @@ const ModuleEditor = forwardRef<ModuleEditorHandle, Props>(
                             <button onClick={() => move(it.id, -1)} title="Monter">↑</button>
                             <button onClick={() => move(it.id, +1)} title="Descendre">↓</button>
                           </div>
-      
+
                           {(it.children?.length ?? 0) > 0 && renderTree(it.children ?? [])}
                         </li>
-                      ))}
+                      )})}
                     </ul>
                   );
       


### PR DESCRIPTION
## Summary
- show item profile color in module editor tree
- add CSS rules for Nantes, Montoir and both

## Testing
- `npm --workspace client test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_683d7da7f8ec8323bae8d2c52e7f105f