### PR TITLE
Add profile color indicators to module items

### DIFF
--- a/client/src/components/ModuleEditor.css
+++ b/client/src/components/ModuleEditor.css
@@ -45,3 +45,4 @@
              button.primary      { background:#008bd2; color:#fff; border:none;
                                    padding:8px 16px; border-radius:4px; cursor:pointer; }
              button.primary:hover{ background:#006fa1; }
+.profile-dot{display:inline-block;width:10px;height:10px;border-radius:2px;margin-left:4px;}

--- a/client/src/components/ModuleEditor.tsx
+++ b/client/src/components/ModuleEditor.tsx
@@ -6,7 +6,12 @@ import AdvancedEditor                  from './AdvancedEditor';
 import {
   IModule, IItem, ILink, IImage, IQuiz,
 } from '../api/modules';
-                import './ModuleEditor.css';
+import './ModuleEditor.css';
+
+const PROFILE_COLORS: Record<string, string> = {
+  Nantes: '#008bd2',
+  Montoir: '#00c49f',
+};
       
                 /* ═════════════════════════ HELPERS GÉNÉRIAUX ═════════════════════════ */
       
@@ -204,7 +209,17 @@ const ModuleEditor = forwardRef<ModuleEditorHandle, Props>(
                             🗑️
                           </button>
 
-                          <span onClick={() => setCurId(it.id)}>{it.title || '∅'}</span>
+                          <span onClick={() => setCurId(it.id)}>
+                            {it.title || '∅'}
+                            {(it.profiles ?? []).map((p) => (
+                              <span
+                                key={p}
+                                className="profile-dot"
+                                style={{ background: PROFILE_COLORS[p] || '#ccc' }}
+                                title={p}
+                              />
+                            ))}
+                          </span>
 
                           <div className="item-acts">
                             <button onClick={() => addItem(it)} title="Ajouter">＋</button>


### PR DESCRIPTION
## Summary
- show colored dots next to item titles to visualize profiles

## Testing
- `npm --workspace client test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683d94d0336c832380e20383fe84f066