### PR TITLE
Support image uploads

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -6,6 +6,7 @@ dotenv.config({ path: path.resolve(__dirname, '../.env') });
 
 import express from 'express';
 import cors from 'cors';
+import fs from 'fs';
 
 import authRouter from './routes/auth';
 import usersRouter from './routes/users';
@@ -14,12 +15,17 @@ import notifsRouter from './routes/notifications';
 import progressRouter from './routes/progress';
 import ticketsRouter from './routes/tickets';
 import checklistRouter from './routes/checklist';
+import imagesRouter from './routes/images';
 
 const app = express();
 const PORT = process.env.PORT || 5000;
 
+const IMG_DIR = path.resolve(__dirname, '../image');
+if (!fs.existsSync(IMG_DIR)) fs.mkdirSync(IMG_DIR);
+
 app.use(cors());
-app.use(express.json());
+app.use(express.json({ limit: '50mb' }));
+app.use('/images', express.static(IMG_DIR));
 
 app.use('/api/auth', authRouter);
 app.use('/api/users', usersRouter);
@@ -28,6 +34,7 @@ app.use('/api/notifications', notifsRouter);
 app.use('/api/progress', progressRouter);
 app.use('/api/tickets', ticketsRouter);
 app.use('/api/checklist-url', checklistRouter);
+app.use('/api/images', imagesRouter);
 
 app.get('/', (_req, res) => {
 res.send('🚀 Backend TS démarré !');

--- a/backend/src/routes/images.ts
+++ b/backend/src/routes/images.ts
@@ -1,0 +1,24 @@
+import { Router } from 'express';
+import fs from 'fs';
+import path from 'path';
+
+const router = Router();
+const DIR = path.resolve(__dirname, '..', 'image');
+
+if (!fs.existsSync(DIR)) fs.mkdirSync(DIR);
+
+router.post('/', (req, res) => {
+  const { data } = req.body as { data?: string };
+  if (!data) return res.status(400).json({ error: 'Donnée manquante' });
+
+  const m = data.match(/^data:(image\/\w+);base64,(.+)$/);
+  if (!m) return res.status(400).json({ error: 'Format invalide' });
+
+  const ext = m[1].split('/')[1];
+  const base64 = m[2];
+  const name = `${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`;
+  fs.writeFileSync(path.join(DIR, name), base64, 'base64');
+  res.json({ url: `/images/${name}` });
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- serve images from `/images`
- allow bigger JSON payloads
- add `/api/images` endpoint to save base64 images
- upload images from the rich text editor instead of embedding base64

## Testing
- `npm test` (fails: Missing script)
- `(backend) npm test` (fails: Missing script)
- `(client) npm test`

------
https://chatgpt.com/codex/tasks/task_e_683d9996398c83239cbc99aa187971a4