### PR TITLE
Add advanced editor features

### DIFF
--- a/client/src/components/AdvancedEditor.tsx
+++ b/client/src/components/AdvancedEditor.tsx
@@ -4,18 +4,23 @@
 import React, { useRef, useState, useCallback, useMemo, useEffect } from 'react';
 import ReactQuill from 'react-quill';
 import axios from 'axios';
+import Quill from 'quill';
+import Table from 'quill/modules/table';
              import 'react-quill/dist/quill.snow\.css';
       
              import hljs from 'highlight.js';
              import 'highlight.js/styles/github.css';
       
              /* HLJS ---------------------------------------------------------------- */
-             hljs.configure({
-               languages: [
-                 'javascript', 'typescript', 'python', 'go',
-                 'java', 'c', 'cpp', 'json', 'bash', 'markdown'
-               ]
-             });
+hljs.configure({
+  languages: [
+    'javascript', 'typescript', 'python', 'go',
+    'java', 'c', 'cpp', 'json', 'bash', 'markdown'
+  ]
+});
+
+Table.register();
+Quill.register('modules/table', Table);
       
              /* -------------------------------------------------------------------- */
              export interface AdvancedEditorProps {
@@ -49,7 +54,14 @@ import axios from 'axios';
           const { data } = await axios.post('/api/images', { data: reader.result });
           const editor = quillRef.current?.getEditor();
           const range  = editor?.getSelection(true);
-          editor?.insertEmbed(range?.index ?? 0, 'image', data.url);
+          if (!editor) return;
+          const index = range?.index ?? 0;
+          editor.insertEmbed(index, 'image', data.url);
+          editor.setSelection(index + 1, 0);
+          const width = prompt("Largeur de l'image en pixels ? (laisser vide pour auto)")?.trim();
+          if (width) {
+            editor.format('width', width);
+          }
         } catch (e) {
           alert('Envoi image impossible');
         }
@@ -62,17 +74,20 @@ import axios from 'axios';
                const modules = useMemo(
                  () => ({
                    syntax: { highlight: (txt: string) => hljs.highlightAuto(txt).value },
-                   toolbar: {
-                     container: [
-                       [{ header: [1, 2, 3, false] }],
-                       ['bold', 'italic', 'underline', 'strike', 'blockquote', 'code-block'],
-                       [{ list: 'ordered' }, { list: 'bullet' }],
-                       ['link', 'image'],
-                       ['clean']
-                     ],
-                     handlers: { image: handleImage }
-                   }
-                 }),
+                  toolbar: {
+                    container: [
+                      [{ header: [1, 2, 3, false] }],
+                      ['bold', 'italic', 'underline', 'strike', 'blockquote', 'code-block'],
+                      [{ color: [] }, { background: [] }],
+                      [{ list: 'ordered' }, { list: 'bullet' }],
+                      [{ align: [] }],
+                      ['link', 'image', 'table'],
+                      ['clean']
+                    ],
+                    handlers: { image: handleImage }
+                  },
+                  table: true
+                }),
                  [handleImage]                   // ne change plus car handleImage est figé
                );
       
@@ -81,7 +96,9 @@ import axios from 'axios';
                    'header', 'bold', 'italic', 'underline', 'strike',
                    'blockquote', 'code-block',
                    'list', 'bullet',
-                   'link', 'image'
+                   'align', 'color', 'background',
+                   'link', 'image', 'table',
+                   'width', 'height'
                  ],
                  []
                );


### PR DESCRIPTION
## Summary
- extend AdvancedEditor toolbar with text color, background, alignment and table
- register Quill table module
- allow setting image width on upload

## Testing
- `npm --workspace client test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683d9de040fc83238993f2e732da2f1a