### PR TITLE
Fix toolbar focus and dynamic item loading

### DIFF
--- a/backend/src/routes/modules.ts
+++ b/backend/src/routes/modules.ts
@@ -19,6 +19,15 @@ function idx(id: string, list = load()) {
   return list.findIndex((m) => m.id === id);
 }
 
+function findItem(items: IItem[], id: string): IItem | null {
+  for (const it of items) {
+    if (it.id === id) return it;
+    const sub = findItem(it.children ?? [], id);
+    if (sub) return sub;
+  }
+  return null;
+}
+
 // GET /api/modules
 router.get('/', (_req, res) => res.json(load()));
 
@@ -26,6 +35,14 @@ router.get('/', (_req, res) => res.json(load()));
 router.get('/:id', (req, res) => {
   const mod = byId(req.params.id);
   return mod ? res.json(mod) : res.status(404).json({ error: 'Module non trouvé' });
+});
+
+// GET /api/modules/:moduleId/items/:itemId
+router.get('/:moduleId/items/:itemId', (req, res) => {
+  const mod = byId(req.params.moduleId);
+  if (!mod) return res.status(404).json({ error: 'Module non trouvé' });
+  const item = findItem(mod.items, req.params.itemId);
+  return item ? res.json(item) : res.status(404).json({ error: 'Item non trouvé' });
 });
 
 // POST /api/modules

--- a/client/src/api/modules.ts
+++ b/client/src/api/modules.ts
@@ -89,3 +89,9 @@ export const getModule  = async (id: string): Promise<IModule> =>
       
 export const updateModule = async (m: IModule): Promise<IModule> =>
   (await axios.put(`/api/modules/${m.id}`, m)).data;
+
+export const getItem = async (
+  moduleId: string,
+  itemId: string,
+): Promise<IItem> => (await axios.get(`/api/modules/${moduleId}/items/${itemId}`)).data;
+

--- a/client/src/components/AdvancedEditor.tsx
+++ b/client/src/components/AdvancedEditor.tsx
@@ -129,9 +129,15 @@ const AdvancedEditor: React.FC<AdvancedEditorProps> = ({ value, onChange }) => {
         <div className="group">
           <button
             title="Couleur du texte"
-            onMouseDown={(e) => {
+            onClick={(e) => {
               e.preventDefault();
-              colorRef.current?.click();
+              if (colorRef.current) {
+                // open color picker without stealing focus
+                if ('showPicker' in colorRef.current)
+                  (colorRef.current as any).showPicker();
+                else
+                  colorRef.current.click();
+              }
             }}
           >
             {/* stroke = couleur actuelle */}
@@ -143,7 +149,14 @@ const AdvancedEditor: React.FC<AdvancedEditorProps> = ({ value, onChange }) => {
             type="color"
             value={currentColor}
             onChange={changeColor}
-            style={{ display: 'none' }}
+            style={{
+              position: 'fixed',
+              left: '-1000px',
+              width: 0,
+              height: 0,
+              pointerEvents: 'none',
+              opacity: 0,
+            }}
           />
         </div>
 

--- a/client/src/components/AdvancedEditor.tsx
+++ b/client/src/components/AdvancedEditor.tsx
@@ -136,38 +136,38 @@ const AdvancedEditor: React.FC<AdvancedEditorProps> = ({ value, onChange }) => {
 
         {/* Bloc 1 – Texte --------------------------------------------- */}
         <div className="group">
-          <button className={editor?.isActive('bold') ? 'active' : ''}      onClick={() => editor?.chain().focus().toggleBold().run()}><Bold size={16}/></button>
-          <button className={editor?.isActive('italic') ? 'active' : ''}    onClick={() => editor?.chain().focus().toggleItalic().run()}><Italic size={16}/></button>
-          <button className={editor?.isActive('underline') ? 'active' : ''} onClick={() => editor?.chain().focus().toggleUnderline().run()}><UnderlineIcon size={16}/></button>
-          <button className={editor?.isActive('strike') ? 'active' : ''}    onClick={() => editor?.chain().focus().toggleStrike().run()}><Strikethrough size={16}/></button>
-          <button className={editor?.isActive('highlight') ? 'active' : ''} onClick={() => editor?.chain().focus().toggleHighlight().run()}><Highlighter size={16}/></button>
-          <button className={editor?.isActive('code') ? 'active' : ''}      onClick={() => editor?.chain().focus().toggleCode().run()}><Code size={16}/></button>
+          <button className={editor?.isFocused && editor.isActive('bold') ? 'active' : ''}      onClick={() => editor?.chain().focus().toggleBold().run()}><Bold size={16}/></button>
+          <button className={editor?.isFocused && editor.isActive('italic') ? 'active' : ''}    onClick={() => editor?.chain().focus().toggleItalic().run()}><Italic size={16}/></button>
+          <button className={editor?.isFocused && editor.isActive('underline') ? 'active' : ''} onClick={() => editor?.chain().focus().toggleUnderline().run()}><UnderlineIcon size={16}/></button>
+          <button className={editor?.isFocused && editor.isActive('strike') ? 'active' : ''}    onClick={() => editor?.chain().focus().toggleStrike().run()}><Strikethrough size={16}/></button>
+          <button className={editor?.isFocused && editor.isActive('highlight') ? 'active' : ''} onClick={() => editor?.chain().focus().toggleHighlight().run()}><Highlighter size={16}/></button>
+          <button className={editor?.isFocused && editor.isActive('code') ? 'active' : ''}      onClick={() => editor?.chain().focus().toggleCode().run()}><Code size={16}/></button>
         </div>
 
         {/* Bloc 2 – Structure ----------------------------------------- */}
         <div className="group">
           <button onClick={() => editor?.chain().focus().setParagraph().run()}><Pilcrow size={16}/></button>
-          <button className={editor?.isActive('heading',{level:1}) ? 'active' : ''} onClick={() => editor?.chain().focus().toggleHeading({level:1}).run()}><Heading1 size={16}/></button>
-          <button className={editor?.isActive('heading',{level:2}) ? 'active' : ''} onClick={() => editor?.chain().focus().toggleHeading({level:2}).run()}><Heading2 size={16}/></button>
-          <button className={editor?.isActive('heading',{level:3}) ? 'active' : ''} onClick={() => editor?.chain().focus().toggleHeading({level:3}).run()}><Heading3 size={16}/></button>
-          <button className={editor?.isActive('blockquote') ? 'active' : ''} onClick={() => editor?.chain().focus().toggleBlockquote().run()}><Quote size={16}/></button>
-          <button className={editor?.isActive('codeBlock') ? 'active' : ''}  onClick={() => editor?.chain().focus().toggleCodeBlock().run()}><Braces size={16}/></button>
+          <button className={editor?.isFocused && editor.isActive('heading',{level:1}) ? 'active' : ''} onClick={() => editor?.chain().focus().toggleHeading({level:1}).run()}><Heading1 size={16}/></button>
+          <button className={editor?.isFocused && editor.isActive('heading',{level:2}) ? 'active' : ''} onClick={() => editor?.chain().focus().toggleHeading({level:2}).run()}><Heading2 size={16}/></button>
+          <button className={editor?.isFocused && editor.isActive('heading',{level:3}) ? 'active' : ''} onClick={() => editor?.chain().focus().toggleHeading({level:3}).run()}><Heading3 size={16}/></button>
+          <button className={editor?.isFocused && editor.isActive('blockquote') ? 'active' : ''} onClick={() => editor?.chain().focus().toggleBlockquote().run()}><Quote size={16}/></button>
+          <button className={editor?.isFocused && editor.isActive('codeBlock') ? 'active' : ''}  onClick={() => editor?.chain().focus().toggleCodeBlock().run()}><Braces size={16}/></button>
           <button onClick={() => editor?.chain().focus().setHorizontalRule().run()}><Minus size={16}/></button>
         </div>
 
         {/* Bloc 3 – Listes ------------------------------------------- */}
         <div className="group">
-          <button className={editor?.isActive('bulletList') ? 'active' : ''}  onClick={() => editor?.chain().focus().toggleBulletList().run()}><List size={16}/></button>
-          <button className={editor?.isActive('orderedList') ? 'active' : ''} onClick={() => editor?.chain().focus().toggleOrderedList().run()}><ListOrdered size={16}/></button>
-          <button className={editor?.isActive('taskList') ? 'active' : ''}    onClick={() => editor?.chain().focus().toggleTaskList().run()}><CheckSquare size={16}/></button>
+          <button className={editor?.isFocused && editor.isActive('bulletList') ? 'active' : ''}  onClick={() => editor?.chain().focus().toggleBulletList().run()}><List size={16}/></button>
+          <button className={editor?.isFocused && editor.isActive('orderedList') ? 'active' : ''} onClick={() => editor?.chain().focus().toggleOrderedList().run()}><ListOrdered size={16}/></button>
+          <button className={editor?.isFocused && editor.isActive('taskList') ? 'active' : ''}    onClick={() => editor?.chain().focus().toggleTaskList().run()}><CheckSquare size={16}/></button>
         </div>
 
         {/* Bloc 4 – Alignement --------------------------------------- */}
         <div className="group">
-          <button className={editor?.isActive({textAlign:'left'}) ? 'active' : ''}    onClick={() => editor?.chain().focus().setTextAlign('left').run()}><AlignLeft size={16}/></button>
-          <button className={editor?.isActive({textAlign:'center'}) ? 'active' : ''}  onClick={() => editor?.chain().focus().setTextAlign('center').run()}><AlignCenter size={16}/></button>
-          <button className={editor?.isActive({textAlign:'right'}) ? 'active' : ''}   onClick={() => editor?.chain().focus().setTextAlign('right').run()}><AlignRight size={16}/></button>
-          <button className={editor?.isActive({textAlign:'justify'}) ? 'active' : ''} onClick={() => editor?.chain().focus().setTextAlign('justify').run()}><AlignJustify size={16}/></button>
+          <button className={editor?.isFocused && editor.isActive({textAlign:'left'}) ? 'active' : ''}    onClick={() => editor?.chain().focus().setTextAlign('left').run()}><AlignLeft size={16}/></button>
+          <button className={editor?.isFocused && editor.isActive({textAlign:'center'}) ? 'active' : ''}  onClick={() => editor?.chain().focus().setTextAlign('center').run()}><AlignCenter size={16}/></button>
+          <button className={editor?.isFocused && editor.isActive({textAlign:'right'}) ? 'active' : ''}   onClick={() => editor?.chain().focus().setTextAlign('right').run()}><AlignRight size={16}/></button>
+          <button className={editor?.isFocused && editor.isActive({textAlign:'justify'}) ? 'active' : ''} onClick={() => editor?.chain().focus().setTextAlign('justify').run()}><AlignJustify size={16}/></button>
         </div>
 
         {/* Bloc 5 – Liens ------------------------------------------- */}

--- a/client/src/components/AdvancedEditor.tsx
+++ b/client/src/components/AdvancedEditor.tsx
@@ -69,10 +69,13 @@ const AdvancedEditor: React.FC<AdvancedEditorProps> = ({ value, onChange }) => {
     onUpdate: ({ editor }) => onChange(editor.getHTML()),
   });
 
+  // keep editor in sync when switching items without interrupting typing
   useEffect(() => {
     if (!editor) return;
-    const cur = editor.getHTML();
-    if (cur !== value) editor.commands.setContent(value, false);
+    // Avoid resetting content while the user is editing
+    if (!editor.isFocused && editor.getHTML() !== value) {
+      editor.commands.setContent(value, false);
+    }
   }, [value, editor]);
 
   /* ---------- Références & commandes utilitaires ---------------- */

--- a/client/src/components/AdvancedEditor.tsx
+++ b/client/src/components/AdvancedEditor.tsx
@@ -111,6 +111,7 @@ const AdvancedEditor: React.FC<AdvancedEditorProps> = ({ value, onChange }) => {
     col === '#000000'
       ? editor.chain().focus().unsetColor().run()
       : editor.chain().focus().setColor(col).run();
+    e.target.blur();
   };
 
   const currentColor = editor?.getAttributes('textStyle').color?.toString() || '#000000';
@@ -125,7 +126,10 @@ const AdvancedEditor: React.FC<AdvancedEditorProps> = ({ value, onChange }) => {
         <div className="group">
           <button
             title="Couleur du texte"
-            onClick={() => colorRef.current?.click()}
+            onMouseDown={(e) => {
+              e.preventDefault();
+              colorRef.current?.click();
+            }}
           >
             {/* stroke = couleur actuelle */}
             <PaintBucket size={16} style={{ color: currentColor }} />

--- a/client/src/components/AdvancedEditor.tsx
+++ b/client/src/components/AdvancedEditor.tsx
@@ -1,7 +1,7 @@
 /* ------------------------------------------------------------------ */
 /*  AdvancedEditor.tsx – police Arial, gras désactivé, couleur texte  */
 /* ------------------------------------------------------------------ */
-import React, { useRef } from 'react';
+import React, { useRef, useEffect } from 'react';
 import { useEditor, EditorContent } from '@tiptap/react';
 import StarterKit               from '@tiptap/starter-kit';
 import Underline                from '@tiptap/extension-underline';
@@ -68,6 +68,12 @@ const AdvancedEditor: React.FC<AdvancedEditorProps> = ({ value, onChange }) => {
     ],
     onUpdate: ({ editor }) => onChange(editor.getHTML()),
   });
+
+  useEffect(() => {
+    if (!editor) return;
+    const cur = editor.getHTML();
+    if (cur !== value) editor.commands.setContent(value, false);
+  }, [value, editor]);
 
   /* ---------- Références & commandes utilitaires ---------------- */
   const colorRef = useRef<HTMLInputElement>(null);

--- a/client/src/components/ModuleEditor.tsx
+++ b/client/src/components/ModuleEditor.tsx
@@ -4,7 +4,7 @@ import React, { useMemo, useState, useEffect, forwardRef, useImperativeHandle } 
 import AdvancedEditor                  from './AdvancedEditor';
       
 import {
-  IModule, IItem, ILink, IImage, IQuiz,
+  IModule, IItem, ILink, IImage, IQuiz, getItem,
 } from '../api/modules';
 import './ModuleEditor.css';
 
@@ -95,6 +95,19 @@ const ModuleEditor = forwardRef<ModuleEditorHandle, Props>(
   useEffect(() => {
     setEdit({ ...module, items: module.items.map(ensureDefaults) });
   }, [module]);
+
+  useEffect(() => {
+    if (!curId || module.id === 'new') return;
+    getItem(module.id, curId)
+      .then(it =>
+        setEdit(prev => ({
+          ...prev,
+          items: mapItems(prev.items, x =>
+            x.id === curId ? ensureDefaults(it) : x,
+          ),
+        })))
+      .catch(console.error);
+  }, [curId, module.id]);
       
                   /* MAJ ciblée d’un item ----------------------------------- */
                   const patchItem = (patch: Partial<IItem>) =>


### PR DESCRIPTION
## Summary
- prevent toolbar buttons from showing active state before focusing the editor
- add endpoint to fetch a single module item
- expose `getItem` API on the client
- refresh item content from backend when switching in module editor

## Testing
- `npm test --silent` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_683ef47750948323b98878097e499227