### PR TITLE
Enable image uploads in advanced editor

### DIFF
--- a/backend/dist/routes/images.js
+++ b/backend/dist/routes/images.js
@@ -22,6 +22,8 @@ router.post('/', (req, res) => {
     const base64 = m[2];
     const name = `${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`;
     fs_1.default.writeFileSync(path_1.default.join(DIR, name), base64, 'base64');
-    res.json({ url: `/images/${name}` });
+    const host = req.get('host');
+    const url = `${req.protocol}://${host}/images/${name}`;
+    res.json({ url });
 });
 exports.default = router;

--- a/backend/src/routes/images.ts
+++ b/backend/src/routes/images.ts
@@ -19,7 +19,9 @@ router.post('/', (req, res) => {
   const base64 = m[2];
   const name = `${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`;
   fs.writeFileSync(path.join(DIR, name), base64, 'base64');
-  res.json({ url: `/images/${name}` });
+  const host = req.get('host');
+  const url = `${req.protocol}://${host}/images/${name}`;
+  res.json({ url });
 });
 
 export default router;

--- a/client/src/api/images.ts
+++ b/client/src/api/images.ts
@@ -1,0 +1,10 @@
+export async function uploadImage(data: string): Promise<string> {
+  const res = await fetch('/api/images', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ data }),
+  });
+  const json = await res.json();
+  if (!res.ok || !json.url) throw new Error(json.error || 'Upload failed');
+  return json.url as string;
+}

--- a/client/src/components/AdvancedEditor.css
+++ b/client/src/components/AdvancedEditor.css
@@ -130,6 +130,12 @@
   position:relative;
   display:inline-block;
   user-select:auto;
+  max-width:100%;
+}
+.image-wrapper img{
+  max-width:100%;
+  height:auto;
+  display:block;
 }
 .image-resize-handle{
   position:absolute;

--- a/client/src/components/AdvancedEditor.css
+++ b/client/src/components/AdvancedEditor.css
@@ -133,13 +133,18 @@
 }
 .image-resize-handle{
   position:absolute;
-  right:-6px;
-  bottom:-6px;
   width:12px;
   height:12px;
   background:#6366f1;               /* indigo-500 */
-  cursor:nwse-resize;
   border-radius:2px;
   display:none;
 }
 .image-wrapper:hover .image-resize-handle{ display:block; }
+.handle-nw{ top:-6px; left:-6px; cursor:nwse-resize; }
+.handle-ne{ top:-6px; right:-6px; cursor:nesw-resize; }
+.handle-sw{ bottom:-6px; left:-6px; cursor:nesw-resize; }
+.handle-se{ bottom:-6px; right:-6px; cursor:nwse-resize; }
+.handle-n{ top:-6px; left:50%; transform:translateX(-50%); cursor:ns-resize; }
+.handle-s{ bottom:-6px; left:50%; transform:translateX(-50%); cursor:ns-resize; }
+.handle-e{ right:-6px; top:50%; transform:translateY(-50%); cursor:ew-resize; }
+.handle-w{ left:-6px; top:50%; transform:translateY(-50%); cursor:ew-resize; }

--- a/client/src/components/AdvancedEditor.css
+++ b/client/src/components/AdvancedEditor.css
@@ -124,3 +124,22 @@
   cursor:col-resize;
   background:#6366f1;               /* indigo-500 */
 }
+
+/* Images redimensionnables --------------------------------------- */
+.image-wrapper{
+  position:relative;
+  display:inline-block;
+  user-select:auto;
+}
+.image-resize-handle{
+  position:absolute;
+  right:-6px;
+  bottom:-6px;
+  width:12px;
+  height:12px;
+  background:#6366f1;               /* indigo-500 */
+  cursor:nwse-resize;
+  border-radius:2px;
+  display:none;
+}
+.image-wrapper:hover .image-resize-handle{ display:block; }

--- a/client/src/components/AdvancedEditor.tsx
+++ b/client/src/components/AdvancedEditor.tsx
@@ -6,7 +6,7 @@ import { useEditor, EditorContent } from '@tiptap/react';
 import StarterKit               from '@tiptap/starter-kit';
 import Underline                from '@tiptap/extension-underline';
 import Link                     from '@tiptap/extension-link';
-import Image                    from '@tiptap/extension-image';
+import ResizableImage           from '../extensions/ResizableImage';
 import Table                    from '@tiptap/extension-table';
 import TableRow                 from '@tiptap/extension-table-row';
 import TableCell                from '@tiptap/extension-table-cell';
@@ -51,7 +51,7 @@ const AdvancedEditor: React.FC<AdvancedEditorProps> = ({ value, onChange }) => {
       StarterKit,
       Underline,
       Link,
-      Image,
+      ResizableImage,
       /* --- TABLE (ordre impératif) -------------------------------- */
       Table.configure({ resizable: true }),
       TableRow,

--- a/client/src/components/AdvancedEditor.tsx
+++ b/client/src/components/AdvancedEditor.tsx
@@ -31,6 +31,7 @@ import {
 } from 'lucide-react';
 
 import './AdvancedEditor.css';
+import { uploadImage } from '../api/images';
 
 const CHAR_LIMIT = 10000;
 
@@ -95,9 +96,27 @@ const AdvancedEditor: React.FC<AdvancedEditorProps> = ({ value, onChange }) => {
     if (url) editor?.chain().focus().setLink({ href: url }).run();
   };
 
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const onSelectImage = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = async () => {
+      try {
+        const url = await uploadImage(reader.result as string);
+        editor?.chain().focus().setImage({ src: url }).run();
+      } catch (err) {
+        console.error(err);
+        alert('Échec de l\u2019upload');
+      }
+    };
+    reader.readAsDataURL(file);
+    e.target.value = '';
+  };
+
   const addImage = () => {
-    const url = prompt('URL de l’image');
-    if (url) editor?.chain().focus().setImage({ src: url }).run();
+    fileRef.current?.click();
   };
 
   /** Efface marks + nœuds (gomme) */
@@ -192,6 +211,13 @@ const AdvancedEditor: React.FC<AdvancedEditorProps> = ({ value, onChange }) => {
         {/* Bloc 6 – Insertion --------------------------------------- */}
         <div className="group">
           <button onClick={addImage}><ImageIcon size={16}/></button>
+          <input
+            ref={fileRef}
+            type="file"
+            accept="image/*"
+            onChange={onSelectImage}
+            style={{ display: 'none' }}
+          />
           <button onClick={promptTable}><Table2 size={16}/></button>
         </div>
 

--- a/client/src/components/AdvancedEditor.tsx
+++ b/client/src/components/AdvancedEditor.tsx
@@ -146,7 +146,7 @@ const AdvancedEditor: React.FC<AdvancedEditorProps> = ({ value, onChange }) => {
   const align = (dir: 'left' | 'center' | 'right' | 'justify') => {
     if (!editor) return;
     if (isImageSelected() && dir !== 'justify') {
-      editor.chain().focus().setImageAlign(dir as 'left' | 'center' | 'right').run();
+      (editor.chain() as any).focus().setImageAlign(dir as 'left' | 'center' | 'right').run();
     } else {
       editor.chain().focus().setTextAlign(dir).run();
     }

--- a/client/src/components/AdvancedEditor.tsx
+++ b/client/src/components/AdvancedEditor.tsx
@@ -19,6 +19,7 @@ import TaskList                 from '@tiptap/extension-task-list';
 import TaskItem                 from '@tiptap/extension-task-item';
 import TextStyle                from '@tiptap/extension-text-style';
 import Color                    from '@tiptap/extension-color';
+import { NodeSelection }        from 'prosemirror-state';
 
 import {
   Bold, Italic, Underline as UnderlineIcon, Strikethrough, Highlighter, Code,
@@ -136,6 +137,30 @@ const AdvancedEditor: React.FC<AdvancedEditorProps> = ({ value, onChange }) => {
     e.target.blur();
   };
 
+  const isImageSelected = () => {
+    if (!editor) return false;
+    const { selection } = editor.state;
+    return selection instanceof NodeSelection && selection.node.type.name === 'image';
+  };
+
+  const align = (dir: 'left' | 'center' | 'right' | 'justify') => {
+    if (!editor) return;
+    if (isImageSelected() && dir !== 'justify') {
+      editor.chain().focus().setImageAlign(dir as 'left' | 'center' | 'right').run();
+    } else {
+      editor.chain().focus().setTextAlign(dir).run();
+    }
+  };
+
+  const activeAlign = (dir: 'left' | 'center' | 'right' | 'justify') => {
+    if (!editor) return false;
+    if (isImageSelected() && dir !== 'justify') {
+      const sel = editor.state.selection as NodeSelection;
+      return sel.node.attrs.align === dir;
+    }
+    return editor.isActive({ textAlign: dir });
+  };
+
   const currentColor = editor?.getAttributes('textStyle').color?.toString() || '#000000';
   const chars        = editor ? editor.storage.characterCount.characters() : 0;
 
@@ -196,10 +221,10 @@ const AdvancedEditor: React.FC<AdvancedEditorProps> = ({ value, onChange }) => {
 
         {/* Bloc 4 – Alignement --------------------------------------- */}
         <div className="group">
-          <button className={editor?.isFocused && editor.isActive({textAlign:'left'}) ? 'active' : ''}    onClick={() => editor?.chain().focus().setTextAlign('left').run()}><AlignLeft size={16}/></button>
-          <button className={editor?.isFocused && editor.isActive({textAlign:'center'}) ? 'active' : ''}  onClick={() => editor?.chain().focus().setTextAlign('center').run()}><AlignCenter size={16}/></button>
-          <button className={editor?.isFocused && editor.isActive({textAlign:'right'}) ? 'active' : ''}   onClick={() => editor?.chain().focus().setTextAlign('right').run()}><AlignRight size={16}/></button>
-          <button className={editor?.isFocused && editor.isActive({textAlign:'justify'}) ? 'active' : ''} onClick={() => editor?.chain().focus().setTextAlign('justify').run()}><AlignJustify size={16}/></button>
+          <button className={activeAlign('left') ? 'active' : ''}    onClick={() => align('left')}><AlignLeft size={16}/></button>
+          <button className={activeAlign('center') ? 'active' : ''}  onClick={() => align('center')}><AlignCenter size={16}/></button>
+          <button className={activeAlign('right') ? 'active' : ''}   onClick={() => align('right')}><AlignRight size={16}/></button>
+          <button className={activeAlign('justify') ? 'active' : ''} onClick={() => align('justify')}><AlignJustify size={16}/></button>
         </div>
 
         {/* Bloc 5 – Liens ------------------------------------------- */}

--- a/client/src/extensions/ResizableImage.ts
+++ b/client/src/extensions/ResizableImage.ts
@@ -16,6 +16,20 @@ const ResizableImage = Image.extend({
         renderHTML: attrs =>
           attrs.height ? { 'data-height': attrs.height } : {},
       },
+      align: {
+        default: 'center',
+        parseHTML: element => element.getAttribute('data-align') || 'center',
+        renderHTML: attrs => ({ 'data-align': attrs.align }),
+      },
+    };
+  },
+
+  addCommands() {
+    return {
+      ...this.parent?.(),
+      setImageAlign:
+        (align: 'left' | 'center' | 'right') => ({ commands }) =>
+          commands.updateAttributes('image', { align }),
     };
   },
 
@@ -34,6 +48,24 @@ const ResizableImage = Image.extend({
       if (node.attrs.height) img.style.height = node.attrs.height;
 
       container.appendChild(img);
+
+      const applyAlign = (a: string) => {
+        container.style.float = '';
+        container.style.display = 'inline-block';
+        container.style.margin = '0';
+        if (a === 'left') {
+          container.style.float = 'left';
+          container.style.margin = '0 1em 1em 0';
+        } else if (a === 'right') {
+          container.style.float = 'right';
+          container.style.margin = '0 0 1em 1em';
+        } else if (a === 'center') {
+          container.style.display = 'block';
+          container.style.margin = '0 auto';
+        }
+      };
+
+      applyAlign(node.attrs.align);
 
       const positions = ['nw','n','ne','e','se','s','sw','w'] as const;
       const handles: {el: HTMLSpanElement; pos: typeof positions[number]}[] = [];
@@ -107,6 +139,7 @@ const ResizableImage = Image.extend({
           else img.style.removeProperty('width');
           if (updatedNode.attrs.height) img.style.height = updatedNode.attrs.height;
           else img.style.removeProperty('height');
+          if (updatedNode.attrs.align !== node.attrs.align) applyAlign(updatedNode.attrs.align);
           return true;
         },
         destroy: () => {

--- a/client/src/extensions/ResizableImage.ts
+++ b/client/src/extensions/ResizableImage.ts
@@ -1,4 +1,5 @@
 import Image from '@tiptap/extension-image';
+import type { CommandProps } from '@tiptap/core';
 
 const ResizableImage = Image.extend({
   addAttributes() {
@@ -28,7 +29,8 @@ const ResizableImage = Image.extend({
     return {
       ...this.parent?.(),
       setImageAlign:
-        (align: 'left' | 'center' | 'right') => ({ commands }) =>
+        (align: 'left' | 'center' | 'right') =>
+        ({ commands }: CommandProps) =>
           commands.updateAttributes('image', { align }),
     };
   },

--- a/client/src/extensions/ResizableImage.ts
+++ b/client/src/extensions/ResizableImage.ts
@@ -1,0 +1,87 @@
+import Image from '@tiptap/extension-image';
+
+const ResizableImage = Image.extend({
+  addAttributes() {
+    return {
+      ...this.parent?.(),
+      width: {
+        default: null,
+        parseHTML: element => element.getAttribute('data-width'),
+        renderHTML: attributes =>
+          attributes.width ? { 'data-width': attributes.width, style: `width:${attributes.width}` } : {},
+      },
+    };
+  },
+
+  addNodeView() {
+    return ({ node, getPos, editor }) => {
+      const container = document.createElement('span');
+      container.className = 'image-wrapper';
+      container.draggable = true;
+      container.contentEditable = 'false';
+
+      const img = document.createElement('img');
+      img.src = node.attrs.src;
+      if (node.attrs.alt) img.alt = node.attrs.alt;
+      if (node.attrs.title) img.title = node.attrs.title;
+      if (node.attrs.width) img.style.width = node.attrs.width;
+
+      const handle = document.createElement('span');
+      handle.className = 'image-resize-handle';
+
+      container.appendChild(img);
+      container.appendChild(handle);
+
+      let startX = 0;
+      let startWidth = 0;
+
+      const onMouseDown = (event: MouseEvent) => {
+        event.preventDefault();
+        startX = event.clientX;
+        startWidth = img.offsetWidth;
+        document.addEventListener('mousemove', onMouseMove);
+        document.addEventListener('mouseup', onMouseUp);
+        container.classList.add('resizing');
+      };
+
+      const onMouseMove = (event: MouseEvent) => {
+        const width = Math.max(50, startWidth + event.clientX - startX);
+        img.style.width = `${width}px`;
+      };
+
+      const onMouseUp = () => {
+        document.removeEventListener('mousemove', onMouseMove);
+        document.removeEventListener('mouseup', onMouseUp);
+        container.classList.remove('resizing');
+        const pos = getPos();
+        if (typeof pos === 'number') {
+          const { tr } = editor.state;
+          tr.setNodeMarkup(pos, undefined, {
+            ...node.attrs,
+            width: img.style.width,
+          });
+          editor.view.dispatch(tr);
+        }
+      };
+
+      handle.addEventListener('mousedown', onMouseDown);
+
+      return {
+        dom: container,
+        contentDOM: null,
+        update: updatedNode => {
+          if (updatedNode.type !== node.type) return false;
+          if (updatedNode.attrs.src !== node.attrs.src) img.src = updatedNode.attrs.src;
+          if (updatedNode.attrs.width) img.style.width = updatedNode.attrs.width;
+          else img.style.removeProperty('width');
+          return true;
+        },
+        destroy: () => {
+          handle.removeEventListener('mousedown', onMouseDown);
+        },
+      };
+    };
+  },
+});
+
+export default ResizableImage;

--- a/client/src/extensions/ResizableImage.ts
+++ b/client/src/extensions/ResizableImage.ts
@@ -41,6 +41,7 @@ const ResizableImage = Image.extend({
       container.className = 'image-wrapper';
       container.draggable = true;
       container.contentEditable = 'false';
+      container.style.maxWidth = '100%';
 
       const img = document.createElement('img');
       img.src = node.attrs.src;
@@ -48,6 +49,8 @@ const ResizableImage = Image.extend({
       if (node.attrs.title) img.title = node.attrs.title;
       if (node.attrs.width) img.style.width = node.attrs.width;
       if (node.attrs.height) img.style.height = node.attrs.height;
+      img.style.maxWidth = '100%';
+      img.style.height = img.style.height || 'auto';
 
       container.appendChild(img);
 
@@ -105,6 +108,8 @@ const ResizableImage = Image.extend({
         if (current.includes('w')) width = Math.max(50, startWidth - dx);
         if (current.includes('s')) height = Math.max(50, startHeight + dy);
         if (current.includes('n')) height = Math.max(50, startHeight - dy);
+        const maxW = (editor.view.dom as HTMLElement).clientWidth;
+        width = Math.min(width, maxW);
         img.style.width = `${width}px`;
         img.style.height = `${height}px`;
       };

--- a/client/src/extensions/ResizableImage.ts
+++ b/client/src/extensions/ResizableImage.ts
@@ -7,8 +7,14 @@ const ResizableImage = Image.extend({
       width: {
         default: null,
         parseHTML: element => element.getAttribute('data-width'),
-        renderHTML: attributes =>
-          attributes.width ? { 'data-width': attributes.width, style: `width:${attributes.width}` } : {},
+        renderHTML: attrs =>
+          attrs.width ? { 'data-width': attrs.width } : {},
+      },
+      height: {
+        default: null,
+        parseHTML: element => element.getAttribute('data-height'),
+        renderHTML: attrs =>
+          attrs.height ? { 'data-height': attrs.height } : {},
       },
     };
   },
@@ -25,46 +31,71 @@ const ResizableImage = Image.extend({
       if (node.attrs.alt) img.alt = node.attrs.alt;
       if (node.attrs.title) img.title = node.attrs.title;
       if (node.attrs.width) img.style.width = node.attrs.width;
-
-      const handle = document.createElement('span');
-      handle.className = 'image-resize-handle';
+      if (node.attrs.height) img.style.height = node.attrs.height;
 
       container.appendChild(img);
-      container.appendChild(handle);
+
+      const positions = ['nw','n','ne','e','se','s','sw','w'] as const;
+      const handles: {el: HTMLSpanElement; pos: typeof positions[number]}[] = [];
+      positions.forEach(pos => {
+        const h = document.createElement('span');
+        h.className = `image-resize-handle handle-${pos}`;
+        container.appendChild(h);
+        handles.push({ el: h, pos });
+      });
 
       let startX = 0;
+      let startY = 0;
       let startWidth = 0;
+      let startHeight = 0;
+      let current: typeof positions[number] | null = null;
 
-      const onMouseDown = (event: MouseEvent) => {
+      const onMouseDown = (pos: typeof positions[number]) => (event: MouseEvent) => {
         event.preventDefault();
+        current = pos;
         startX = event.clientX;
+        startY = event.clientY;
         startWidth = img.offsetWidth;
+        startHeight = img.offsetHeight;
         document.addEventListener('mousemove', onMouseMove);
         document.addEventListener('mouseup', onMouseUp);
-        container.classList.add('resizing');
       };
 
       const onMouseMove = (event: MouseEvent) => {
-        const width = Math.max(50, startWidth + event.clientX - startX);
+        if (!current) return;
+        let width = startWidth;
+        let height = startHeight;
+        const dx = event.clientX - startX;
+        const dy = event.clientY - startY;
+        if (current.includes('e')) width = Math.max(50, startWidth + dx);
+        if (current.includes('w')) width = Math.max(50, startWidth - dx);
+        if (current.includes('s')) height = Math.max(50, startHeight + dy);
+        if (current.includes('n')) height = Math.max(50, startHeight - dy);
         img.style.width = `${width}px`;
+        img.style.height = `${height}px`;
       };
 
       const onMouseUp = () => {
         document.removeEventListener('mousemove', onMouseMove);
         document.removeEventListener('mouseup', onMouseUp);
-        container.classList.remove('resizing');
         const pos = getPos();
         if (typeof pos === 'number') {
           const { tr } = editor.state;
           tr.setNodeMarkup(pos, undefined, {
             ...node.attrs,
             width: img.style.width,
+            height: img.style.height,
           });
           editor.view.dispatch(tr);
         }
+        current = null;
       };
 
-      handle.addEventListener('mousedown', onMouseDown);
+      const handlers = handles.map(h => {
+        const fn = onMouseDown(h.pos);
+        h.el.addEventListener('mousedown', fn);
+        return { el: h.el, fn };
+      });
 
       return {
         dom: container,
@@ -74,10 +105,12 @@ const ResizableImage = Image.extend({
           if (updatedNode.attrs.src !== node.attrs.src) img.src = updatedNode.attrs.src;
           if (updatedNode.attrs.width) img.style.width = updatedNode.attrs.width;
           else img.style.removeProperty('width');
+          if (updatedNode.attrs.height) img.style.height = updatedNode.attrs.height;
+          else img.style.removeProperty('height');
           return true;
         },
         destroy: () => {
-          handle.removeEventListener('mousedown', onMouseDown);
+          handlers.forEach(h => h.el.removeEventListener('mousedown', h.fn));
         },
       };
     };


### PR DESCRIPTION
## Summary
- allow uploading images through a hidden file input in the advanced editor
- store uploaded images on the backend via new `/api/images` endpoint
- expose new `uploadImage` API helper for the client

## Testing
- `CI=true npm --workspace client test --silent` *(fails: No tests found)*
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683f37f959f883238326748c30803e90