### PR TITLE
Revise dashboard layouts

### DIFF
--- a/client/src/components/ProgressBar.css
+++ b/client/src/components/ProgressBar.css
@@ -9,15 +9,15 @@
 .progress-bar-fill {
   background: linear-gradient(90deg, #0099f7, #043962);
   background-size: 200% 100%;
-  animation: progress-move 2s linear infinite;
+  animation: progress-move 5s linear infinite ;
   height: 100%;
   border-radius: 4px;
   transition: width 0.3s ease;
 }
 
 @keyframes progress-move {
-  from { background-position: 0 0; }
-  to { background-position: 200% 0; }
+  from { background-position: 200% 0; }
+  to { background-position: 0 0; }
 }
 
 .progress-bar-text {

--- a/client/src/components/ProgressBar.css
+++ b/client/src/components/ProgressBar.css
@@ -8,9 +8,16 @@
 
 .progress-bar-fill {
   background: linear-gradient(90deg, #0099f7, #043962);
+  background-size: 200% 100%;
+  animation: progress-move 2s linear infinite;
   height: 100%;
   border-radius: 4px;
   transition: width 0.3s ease;
+}
+
+@keyframes progress-move {
+  from { background-position: 0 0; }
+  to { background-position: 200% 0; }
 }
 
 .progress-bar-text {

--- a/client/src/pages/AdminDashboardPage.css
+++ b/client/src/pages/AdminDashboardPage.css
@@ -58,9 +58,13 @@
                border-collapse: collapse;
              }
 
-             .admin-dashboard .chart-area {
-               margin-bottom: 2rem;
-             }
+.admin-dashboard .chart-area {
+  margin-bottom: 2rem;
+}
+
+.admin-dashboard .site-info {
+  margin-bottom: 2rem;
+}
     
              .admin-dashboard th,
              .admin-dashboard td {

--- a/client/src/pages/AdminDashboardPage.css
+++ b/client/src/pages/AdminDashboardPage.css
@@ -11,18 +11,18 @@
     
              .admin-dashboard .cards {
                display: flex;
+               flex-direction: column;
                gap: 1rem;
-               flex-wrap: wrap;
                margin-bottom: 1.5rem;
              }
     
              .admin-dashboard .card {
-               flex: 1 1 180px;
                background: #f9f9f9;
                padding: 1rem;
                border-radius: 8px;
                text-align: center;
                box-shadow: 0 1px 3px rgba(0, 0, 0, .1);
+               width: 100%;
              }
     
              .admin-dashboard .big {

--- a/client/src/pages/AdminDashboardPage.tsx
+++ b/client/src/pages/AdminDashboardPage.tsx
@@ -121,11 +121,14 @@ import { PieChart, Pie, Cell, Legend, ResponsiveContainer } from 'recharts';
     ];
     const COLORS = ['#043962', '#008bd2', '#00c49f'];
 
-    const siteMap = users.reduce<Record<string, number>>((acc,u)=>{
+    const siteMap = users.reduce<Record<string, number>>((acc, u) => {
       const sites = u.role === 'manager' ? (u.sites || []) : [u.site];
-      sites.forEach(s=>{ if(s){ acc[s] = (acc[s] || 0) + 1; } });
+      sites.forEach(s => {
+        if (s) acc[s] = (acc[s] || 0) + 1;
+      });
       return acc;
-    },{});
+    }, {});
+    const siteData = Object.entries(siteMap).map(([name, value]) => ({ name, value }));
 
      return (
        <div className="admin-dashboard">
@@ -150,13 +153,18 @@ import { PieChart, Pie, Cell, Legend, ResponsiveContainer } from 'recharts';
           </ResponsiveContainer>
         </section>
 
-        <section className="site-info">
+        <section className="chart-area">
           <h3>Répartition par site</h3>
-          <ul>
-            {Object.entries(siteMap).map(([s,c]) => (
-              <li key={s}>{s}: {c}</li>
-            ))}
-          </ul>
+          <ResponsiveContainer width="100%" height={220}>
+            <PieChart>
+              <Pie data={siteData} dataKey="value" nameKey="name" outerRadius={80} label>
+                {siteData.map((_, i) => (
+                  <Cell key={i} fill={COLORS[i % COLORS.length]} />
+                ))}
+              </Pie>
+              <Legend />
+            </PieChart>
+          </ResponsiveContainer>
         </section>
 
         <div className="quick">

--- a/client/src/pages/AdminDashboardPage.tsx
+++ b/client/src/pages/AdminDashboardPage.tsx
@@ -121,6 +121,12 @@ import { PieChart, Pie, Cell, Legend, ResponsiveContainer } from 'recharts';
     ];
     const COLORS = ['#043962', '#008bd2', '#00c49f'];
 
+    const siteMap = users.reduce<Record<string, number>>((acc,u)=>{
+      const sites = u.role === 'manager' ? (u.sites || []) : [u.site];
+      sites.forEach(s=>{ if(s){ acc[s] = (acc[s] || 0) + 1; } });
+      return acc;
+    },{});
+
      return (
        <div className="admin-dashboard">
          <h1>Tableau de bord admin</h1>
@@ -142,6 +148,15 @@ import { PieChart, Pie, Cell, Legend, ResponsiveContainer } from 'recharts';
               <Legend />
             </PieChart>
           </ResponsiveContainer>
+        </section>
+
+        <section className="site-info">
+          <h3>Répartition par site</h3>
+          <ul>
+            {Object.entries(siteMap).map(([s,c]) => (
+              <li key={s}>{s}: {c}</li>
+            ))}
+          </ul>
         </section>
 
         <div className="quick">

--- a/client/src/pages/ManagerDashboardPage.css
+++ b/client/src/pages/ManagerDashboardPage.css
@@ -1,0 +1,130 @@
+.manager-dashboard {
+  padding: 1.5rem;
+  max-width: 960px;
+  margin: auto;
+}
+
+.manager-dashboard h1 {
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.manager-dashboard .cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.manager-dashboard .card {
+  background: #f9f9f9;
+  padding: 1rem;
+  border-radius: 8px;
+  text-align: center;
+  box-shadow: 0 1px 3px rgba(0,0,0,.1);
+  flex: 1;
+  min-width: 250px;
+}
+
+.manager-dashboard .progress-card {
+  margin-bottom: 1.5rem;
+}
+
+.manager-dashboard .big {
+  font-size: 2rem;
+  font-weight: bold;
+  color: #008BD2;
+  margin-top: .5rem;
+}
+
+/* ---- actions rapides (roue) ---- */
+.quick-wheel {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  width: 220px;
+  height: 220px;
+}
+.quick-wheel .center {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 1;
+  background: #008bd2;
+  color: #fff;
+  border: none;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  cursor: pointer;
+}
+.quick-wheel a {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0);
+  background: #008bd2;
+  color: #fff;
+  border-radius: 50%;
+  width: 72px;
+  height: 72px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  font-size: 1.2rem;
+  opacity: 0;
+  transition: transform .3s, opacity .3s;
+}
+.quick-wheel a span.label {
+  font-size: .65rem;
+  margin-top: 2px;
+}
+.quick-wheel.open a {
+  opacity: 1;
+  transform: translate(-50%, -50%) scale(1);
+}
+.quick-wheel.open a:nth-child(2) {
+  transform: translate(-50%, -50%) rotate(0deg) translate(100px) rotate(0deg);
+}
+.quick-wheel.open a:nth-child(3) {
+  transform: translate(-50%, -50%) rotate(72deg) translate(100px) rotate(-72deg);
+}
+.quick-wheel.open a:nth-child(4) {
+  transform: translate(-50%, -50%) rotate(144deg) translate(100px) rotate(-144deg);
+}
+.quick-wheel.open a:nth-child(5) {
+  transform: translate(-50%, -50%) rotate(216deg) translate(100px) rotate(-216deg);
+}
+.quick-wheel.open a:nth-child(6) {
+  transform: translate(-50%, -50%) rotate(288deg) translate(100px) rotate(-288deg);
+}
+.btn {
+  background: #008bd2;
+  color: #fff;
+  border: none;
+  border-radius: 50%;
+  width: 72px;
+  height: 72px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+}
+.btn:hover {
+  background: #006fa1;
+}
+
+.manager-dashboard table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+.manager-dashboard th,
+.manager-dashboard td {
+  border-bottom: 1px solid #e0e0e0;
+  padding: .5rem .75rem;
+}

--- a/client/src/pages/ManagerDashboardPage.css
+++ b/client/src/pages/ManagerDashboardPage.css
@@ -21,6 +21,7 @@
   padding: 1rem;
   border-radius: 8px;
   text-align: center;
+  
   box-shadow: 0 1px 3px rgba(0,0,0,.1);
   flex: 1;
   min-width: 250px;

--- a/client/src/pages/ManagerDashboardPage.tsx
+++ b/client/src/pages/ManagerDashboardPage.tsx
@@ -8,6 +8,7 @@
   import ProgressBar   from '../components/ProgressBar';
   import { Link }      from 'react-router-dom';
   import { PieChart, Pie, Cell, Legend, ResponsiveContainer } from 'recharts';
+  const COLORS = ['#043962', '#008bd2', '#00c49f'];
 
    export default function ManagerDashboardPage() {
     const { user } = useAuth();               // rôle == manager

--- a/client/src/pages/ManagerDashboardPage.tsx
+++ b/client/src/pages/ManagerDashboardPage.tsx
@@ -2,20 +2,21 @@
    ────────────────────────────────────────── */
    import React, { useEffect, useState } from 'react';
    import { useAuth }   from '../context/AuthContext';
-   import styled        from 'styled-components';
    import { IUser }     from '../api/auth';
   import { IProgress, IModule, getModules } from '../api/modules';
   import ProgressBar   from '../components/ProgressBar';
   import { Link }      from 'react-router-dom';
-  import { PieChart, Pie, Cell, Legend, ResponsiveContainer } from 'recharts';
-  const COLORS = ['#043962', '#008bd2', '#00c49f'];
+import { PieChart, Pie, Cell, Legend, ResponsiveContainer } from 'recharts';
+import './ManagerDashboardPage.css';
+const COLORS = ['#043962', '#008bd2', '#00c49f'];
 
    export default function ManagerDashboardPage() {
-    const { user } = useAuth();               // rôle == manager
-    const [caf,setCaf]         = useState<IUser[]>([]);
-    const [prog,setProg]       = useState<IProgress[]>([]);
-    const [mods,setMods]       = useState<IModule[]>([]);
-    const [loading,setLoading] = useState(true);
+  const { user } = useAuth();               // rôle == manager
+  const [caf,setCaf]         = useState<IUser[]>([]);
+  const [prog,setProg]       = useState<IProgress[]>([]);
+  const [mods,setMods]       = useState<IModule[]>([]);
+  const [loading,setLoading] = useState(true);
+  const [wheelOpen,setWheelOpen] = useState(false);
 
     useEffect(()=>{
       Promise.all([
@@ -42,7 +43,7 @@
      if(loading) return <p style={{padding:'2rem'}}>Chargement…</p>;
 
      return (
-       <Wrapper>
+       <div className="manager-dashboard">
          <h1>Dashboard manager</h1>
 
         <section className="cards">
@@ -62,9 +63,9 @@
           </div>
         </section>
 
-        {/* ----------- actions rapides ----------- */}
-       <div className="quick-wheel">
-         <button className="center">☰</button>
+      {/* ----------- actions rapides ----------- */}
+       <div className={`quick-wheel${wheelOpen ? ' open' : ''}`}>
+         <button className="center" onClick={() => setWheelOpen(o => !o)}>☰</button>
          <Link to="/manager/create" className="btn" title="Créer un compte CAF">
            <span>➕</span><span className="label">Créer</span>
          </Link>
@@ -101,7 +102,7 @@
              ))}
            </tbody>
          </table>
-       </Wrapper>
+       </div>
      );
 
      async function resetPwd(id:string){
@@ -116,34 +117,6 @@
      }
    }
 
-   const StatCard = ({label,value}:{label:string;value:number})=>(
-     <div className="card"><h3>{label}</h3><p className="big">{value}</p></div>
-   );
-
-   const Wrapper = styled.div`
-     padding:1.5rem;
-     max-width:960px;
-     margin:auto;
-     .cards{display:flex;flex-direction:column;gap:1rem;margin-bottom:1.5rem}
-     .card{background:#f9f9f9;padding:1rem;border-radius:8px;text-align:center;
-           box-shadow:0 1px 3px rgba(0,0,0,.1);width:100%}
-     .progress-card{margin-bottom:1.5rem}
-     .big{font-size:2rem;font-weight:bold;color:#008BD2;margin-top:.5rem}
-   
-    /* ---- actions rapides (roue) ---- */
-    .quick-wheel{position:fixed;bottom:1.5rem;right:1.5rem;width:220px;height:220px;}
-    .quick-wheel .center{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);z-index:1;background:#008bd2;color:#fff;border:none;width:48px;height:48px;border-radius:50%;}
-    .quick-wheel a{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%) scale(0);background:#008bd2;color:#fff;border-radius:50%;width:72px;height:72px;display:flex;flex-direction:column;align-items:center;justify-content:center;text-decoration:none;font-size:1.2rem;opacity:0;transition:transform .3s,opacity .3s;}
-    .quick-wheel a span.label{font-size:.65rem;margin-top:2px;}
-    .quick-wheel:hover a{opacity:1;transform:translate(-50%,-50%) scale(1);}
-    .quick-wheel:hover a:nth-child(2){transform:translate(-50%,-50%) rotate(0deg) translate(100px) rotate(0deg);}
-    .quick-wheel:hover a:nth-child(3){transform:translate(-50%,-50%) rotate(72deg) translate(100px) rotate(-72deg);}
-    .quick-wheel:hover a:nth-child(4){transform:translate(-50%,-50%) rotate(144deg) translate(100px) rotate(-144deg);}
-    .quick-wheel:hover a:nth-child(5){transform:translate(-50%,-50%) rotate(216deg) translate(100px) rotate(-216deg);}
-    .quick-wheel:hover a:nth-child(6){transform:translate(-50%,-50%) rotate(288deg) translate(100px) rotate(-288deg);}
-    .btn{background:#008bd2;color:#fff;border:none;border-radius:50%;width:72px;height:72px;display:flex;flex-direction:column;align-items:center;justify-content:center;text-decoration:none;}
-    .btn:hover{background:#006fa1}
-   
-     table{width:100%;border-collapse:collapse;margin-top:1rem}
-     th,td{border-bottom:1px solid #e0e0e0;padding:.5rem .75rem}
-  `;
+  const StatCard = ({label,value}:{label:string;value:number})=>(
+    <div className="card"><h3>{label}</h3><p className="big">{value}</p></div>
+  );

--- a/client/src/pages/ManagerDashboardPage.tsx
+++ b/client/src/pages/ManagerDashboardPage.tsx
@@ -7,6 +7,7 @@
   import { IProgress, IModule, getModules } from '../api/modules';
   import ProgressBar   from '../components/ProgressBar';
   import { Link }      from 'react-router-dom';
+  import { PieChart, Pie, Cell, Legend, ResponsiveContainer } from 'recharts';
 
    export default function ManagerDashboardPage() {
     const { user } = useAuth();               // rôle == manager
@@ -30,6 +31,7 @@
       acc[site] = (acc[site] || 0) + 1;
       return acc;
     }, {});
+    const siteData = Object.entries(siteMap).map(([name, value]) => ({ name, value }));
 
     /* progression globale */
     const itemsPerUser = mods.reduce((n,m)=> n + (m.items?.length ?? 0), 0);
@@ -43,29 +45,46 @@
          <h1>Dashboard manager</h1>
 
         <section className="cards">
-          <StatCard label="CAF supervisés" value={caf.length}/>
+          <StatCard label="CAF supervisés" value={caf.length} />
           <div className="card">
-            <h3>Par site</h3>
-            <ul>
-              {Object.entries(siteMap).map(([s,c]) => (
-                <li key={s}>{s}: {c}</li>
-              ))}
-            </ul>
+            <h3>Répartition par site</h3>
+            <ResponsiveContainer width="100%" height={220}>
+              <PieChart>
+                <Pie data={siteData} dataKey="value" nameKey="name" outerRadius={80} label>
+                  {siteData.map((_, i) => (
+                    <Cell key={i} fill={COLORS[i % COLORS.length]} />
+                  ))}
+                </Pie>
+                <Legend />
+              </PieChart>
+            </ResponsiveContainer>
           </div>
         </section>
 
         {/* ----------- actions rapides ----------- */}
        <div className="quick-wheel">
          <button className="center">☰</button>
-         <Link to="/manager/create" className="btn" title="Créer un compte CAF">+</Link>
-         <Link to="/manager/modules" className="btn" title="Modules">📝</Link>
-         <Link to="/manager/tickets" className="btn" title="Tickets">📋</Link>
-         <Link to="/manager/checklist-url" className="btn" title="Checklist">🔗</Link>
-         <Link to="/manager/progress" className="btn" title="Progression">📊</Link>
+         <Link to="/manager/create" className="btn" title="Créer un compte CAF">
+           <span>➕</span><span className="label">Créer</span>
+         </Link>
+         <Link to="/manager/modules" className="btn" title="Modules">
+           <span>📝</span><span className="label">Modules</span>
+         </Link>
+         <Link to="/manager/tickets" className="btn" title="Tickets">
+           <span>📋</span><span className="label">Tickets</span>
+         </Link>
+         <Link to="/manager/checklist-url" className="btn" title="Checklist">
+           <span>🔗</span><span className="label">Checklist</span>
+         </Link>
+         <Link to="/manager/progress" className="btn" title="Progression">
+           <span>📊</span><span className="label">Progression</span>
+         </Link>
        </div>
 
-        <h2>Progression globale</h2>
-       <ProgressBar current={totalVisited} total={totalPossible} />
+        <div className="card progress-card">
+          <h3>Avancée globale</h3>
+          <ProgressBar current={totalVisited} total={totalPossible} />
+        </div>
 
          <h2>Changer un mot de passe</h2>
          <table>
@@ -100,23 +119,28 @@
      <div className="card"><h3>{label}</h3><p className="big">{value}</p></div>
    );
 
-   const Wrapper = styled.div`     padding:1.5rem; max-width:960px; margin:auto;
-     .cards{display:flex;gap:1rem;flex-wrap:wrap;margin-bottom:1.5rem}
-     .card{flex:1 1 180px;background:#f9f9f9;padding:1rem;border-radius:8px;
-           text-align:center;box-shadow:0 1px 3px rgba(0,0,0,.1)}
+   const Wrapper = styled.div`
+     padding:1.5rem;
+     max-width:960px;
+     margin:auto;
+     .cards{display:flex;flex-direction:column;gap:1rem;margin-bottom:1.5rem}
+     .card{background:#f9f9f9;padding:1rem;border-radius:8px;text-align:center;
+           box-shadow:0 1px 3px rgba(0,0,0,.1);width:100%}
+     .progress-card{margin-bottom:1.5rem}
      .big{font-size:2rem;font-weight:bold;color:#008BD2;margin-top:.5rem}
    
     /* ---- actions rapides (roue) ---- */
-    .quick-wheel{position:relative;width:220px;height:220px;margin:1.5rem auto;}
+    .quick-wheel{position:fixed;bottom:1.5rem;right:1.5rem;width:220px;height:220px;}
     .quick-wheel .center{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);z-index:1;background:#008bd2;color:#fff;border:none;width:48px;height:48px;border-radius:50%;}
-    .quick-wheel a{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);background:#008bd2;color:#fff;border-radius:50%;width:48px;height:48px;display:flex;align-items:center;justify-content:center;opacity:0;transition:transform .3s,opacity .3s;}
-    .quick-wheel:hover a{opacity:1;}
-    .quick-wheel:hover a:nth-child(2){transform:translate(-50%,-50%) rotate(0deg) translate(90px) rotate(0deg);}
-    .quick-wheel:hover a:nth-child(3){transform:translate(-50%,-50%) rotate(72deg) translate(90px) rotate(-72deg);}
-    .quick-wheel:hover a:nth-child(4){transform:translate(-50%,-50%) rotate(144deg) translate(90px) rotate(-144deg);}
-    .quick-wheel:hover a:nth-child(5){transform:translate(-50%,-50%) rotate(216deg) translate(90px) rotate(-216deg);}
-    .quick-wheel:hover a:nth-child(6){transform:translate(-50%,-50%) rotate(288deg) translate(90px) rotate(-288deg);}
-    .btn{background:#008bd2;color:#fff;border:none;width:48px;height:48px;border-radius:50%;display:flex;align-items:center;justify-content:center;}
+    .quick-wheel a{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%) scale(0);background:#008bd2;color:#fff;border-radius:50%;width:72px;height:72px;display:flex;flex-direction:column;align-items:center;justify-content:center;text-decoration:none;font-size:1.2rem;opacity:0;transition:transform .3s,opacity .3s;}
+    .quick-wheel a span.label{font-size:.65rem;margin-top:2px;}
+    .quick-wheel:hover a{opacity:1;transform:translate(-50%,-50%) scale(1);}
+    .quick-wheel:hover a:nth-child(2){transform:translate(-50%,-50%) rotate(0deg) translate(100px) rotate(0deg);}
+    .quick-wheel:hover a:nth-child(3){transform:translate(-50%,-50%) rotate(72deg) translate(100px) rotate(-72deg);}
+    .quick-wheel:hover a:nth-child(4){transform:translate(-50%,-50%) rotate(144deg) translate(100px) rotate(-144deg);}
+    .quick-wheel:hover a:nth-child(5){transform:translate(-50%,-50%) rotate(216deg) translate(100px) rotate(-216deg);}
+    .quick-wheel:hover a:nth-child(6){transform:translate(-50%,-50%) rotate(288deg) translate(100px) rotate(-288deg);}
+    .btn{background:#008bd2;color:#fff;border:none;border-radius:50%;width:72px;height:72px;display:flex;flex-direction:column;align-items:center;justify-content:center;text-decoration:none;}
     .btn:hover{background:#006fa1}
    
      table{width:100%;border-collapse:collapse;margin-top:1rem}


### PR DESCRIPTION
## Summary
- tweak admin dashboard style to show site distribution
- show site repartition for all accounts in AdminDashboard
- rework ManagerDashboard with site stats, global KPI progress bar and radial quick menu

## Testing
- `npm --workspace client test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6840386653b88323b8d02414c076e9a5