### PR TITLE
Revise dashboard layouts

### DIFF
--- a/client/src/components/CircleMenu.css
+++ b/client/src/components/CircleMenu.css
@@ -1,11 +1,12 @@
 .menu--circle {
   position: fixed;
-  top: 1.5rem;
-  left: 1.5rem;
-  width: 220px;
+  background-color: none;
+  top: 0%;
+  left: -4%;
+  width: 200px;
   height: 220px;
   pointer-events: none;
-  --distance: 100px;
+  --distance: 90px;
 }
 
 .menu__toggle {
@@ -13,9 +14,9 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  width: 64px;
-  height: 64px;
-  background: #fff;
+  width: 60px;
+  height: 60px;
+  background: none;
   border: none;
   border-radius: 50%;
   cursor: pointer;
@@ -24,21 +25,33 @@
 
 .icon {
   position: absolute;
-  top: 70%;
-  left: 70%;
+  font-size: 150%;
+  font-weight: bold;
+  color: #000;
+  top: 50%;
+  left: 50%;
   transform: translate(-50%, -50%);
 }
+
 
 .hamburger,
 .hamburger::before,
 .hamburger::after {
   content: '';
+  
   display: block;
   width: 26px;
-  border-top: 3px solid #392338;
+  border-top: 3px solid #000000;
+  
   margin: 5px 0;
-  transition: transform .4s, border-color .4s;
+  transition: transform .4s, border-color 0;
 }
+
+.menu__toggle:hover{
+  background: none;
+  transform: translate(-50%, -50%) scale(1.2);
+}
+
 
 .menu--circle.open .hamburger {
   border-color: transparent;
@@ -54,17 +67,18 @@
 
 .menu__listings {
   position: absolute;
+  
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
   border-radius: 50%;
-  transform: scale(0.1) rotate(0deg);
-  transition: transform .5s;
+  transform: rotate(0deg);
+  transition: transform .9s;
 }
 
 .menu--circle.open .menu__listings {
-  transform: scale(1) rotate(10deg);
+  transform:  rotate(0deg);
 }
 
 .circle {
@@ -84,7 +98,7 @@
   left: 50%;
   opacity: 0;
   transform: translate(-50%, -50%) scale(0);
-  transition: transform .4s, opacity .3s;
+  transition: transform .2s, opacity .3s;
 }
 
 .menu--circle.open .circle li {
@@ -97,9 +111,11 @@
 
 
 .button {
-  background: #fff;
+  background: none;
+  font-size: 150%;
+  font-weight: bold;
   color: #392338;
-  border-radius: 50%;
+  border-radius: 20%;
   width: 64px;
   height: 64px;
   display: flex;
@@ -110,32 +126,51 @@
   pointer-events: auto;
 }
 .button:hover {
-  background: #c1264e;
-  color: #fff;
+  background: none;
+  transform: scale(1.2);
 }
+  
+
 .button .label {
-  font-size: 0.6rem;
+  font-size: 50%;
   margin-top: 2px;
 }
 
 .rotate {
-  position: absolute;
-  top: 8px;
-  left: 50%;
+  position: relative;
+  bottom: 40%;
+  left: 65%;
+
+  /* Centrage et état fermé (caché/zoom 0) */
   transform: translate(-50%, -50%) scale(0);
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
-  background: #008bd2;
-  color: #fff;
-  border: none;
+
+  width: 10%;
+  height: 10%;
+
+  background: none;
+  /* Meilleur contraste sinon le texte sera invisible */
+
+  margin: 0; /* Supprime les marges */
+  padding: 0; /* Facultatif mais souvent utile */
+
   cursor: pointer;
   pointer-events: auto;
-  opacity: 0;
-  transition: opacity .3s, transform .3s;
+
+  opacity: 1;
+  transition: 
+    opacity 0.3s ease, 
+    transform 0.3s ease;
 }
 
+/* État ouvert : on agrandit et on affiche */
 .menu--circle.open .rotate {
-  opacity: 1;
-  transform: translate(-50%, -50%) scale(1);
+  transform: translate(-50%, -50%) scale(1.5);
 }
+
+/* Effet au survol */
+.menu--circle.open .rotate:hover {
+  position: relative;
+  background: none;
+  transform: translate(-50%, -50%) scale(1.9);
+}
+

--- a/client/src/components/CircleMenu.css
+++ b/client/src/components/CircleMenu.css
@@ -1,0 +1,118 @@
+.menu--circle {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  width: 220px;
+  height: 220px;
+  pointer-events: none;
+}
+
+.menu__toggle {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 64px;
+  height: 64px;
+  background: #fff;
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  pointer-events: auto;
+}
+
+.icon {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.hamburger,
+.hamburger::before,
+.hamburger::after {
+  content: '';
+  display: block;
+  width: 26px;
+  border-top: 3px solid #392338;
+  margin: 5px 0;
+  transition: transform .4s, border-color .4s;
+}
+
+.menu--circle.open .hamburger {
+  border-color: transparent;
+}
+
+.menu--circle.open .hamburger::before {
+  transform: translateY(8px) rotate(45deg);
+}
+
+.menu--circle.open .hamburger::after {
+  transform: translateY(-8px) rotate(-45deg);
+}
+
+.menu__listings {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  transform: scale(0);
+  transition: transform .5s;
+}
+
+.menu--circle.open .menu__listings {
+  transform: scale(1);
+}
+
+.circle {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  height: 100%;
+  width: 100%;
+  position: relative;
+}
+
+.circle li {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  opacity: 0;
+  transform: translate(-50%, -50%) scale(0);
+  transition: transform .4s, opacity .3s;
+}
+
+.menu--circle.open .circle li {
+  opacity: 1;
+  transform: translate(-50%, -50%) scale(1) rotate(var(--angle)) translate(90px) rotate(calc(var(--angle) * -1));
+}
+
+.circle li:nth-child(1) { --angle: 0deg; }
+.circle li:nth-child(2) { --angle: 72deg; }
+.circle li:nth-child(3) { --angle: 144deg; }
+.circle li:nth-child(4) { --angle: 216deg; }
+.circle li:nth-child(5) { --angle: 288deg; }
+
+.button {
+  background: #fff;
+  color: #392338;
+  border-radius: 50%;
+  width: 64px;
+  height: 64px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  pointer-events: auto;
+}
+.button:hover {
+  background: #c1264e;
+  color: #fff;
+}
+.button .label {
+  font-size: 0.6rem;
+  margin-top: 2px;
+}

--- a/client/src/components/CircleMenu.css
+++ b/client/src/components/CircleMenu.css
@@ -90,8 +90,8 @@
 }
 
 .circle li:nth-child(1) { --angle: 0deg; }
-.circle li:nth-child(2) { --angle: 120deg; }
-.circle li:nth-child(3) { --angle: 240deg; }
+.circle li:nth-child(2) { --angle: 30deg; }
+.circle li:nth-child(3) { --angle: 60deg; }
 
 .button {
   background: #fff;

--- a/client/src/components/CircleMenu.css
+++ b/client/src/components/CircleMenu.css
@@ -1,7 +1,7 @@
 .menu--circle {
   position: fixed;
-  bottom: 1.5rem;
-  right: 1.5rem;
+  top: 1.5rem;
+  left: 1.5rem;
   width: 220px;
   height: 220px;
   pointer-events: none;
@@ -90,10 +90,8 @@
 }
 
 .circle li:nth-child(1) { --angle: 0deg; }
-.circle li:nth-child(2) { --angle: 72deg; }
-.circle li:nth-child(3) { --angle: 144deg; }
-.circle li:nth-child(4) { --angle: 216deg; }
-.circle li:nth-child(5) { --angle: 288deg; }
+.circle li:nth-child(2) { --angle: 120deg; }
+.circle li:nth-child(3) { --angle: 240deg; }
 
 .button {
   background: #fff;
@@ -115,4 +113,26 @@
 .button .label {
   font-size: 0.6rem;
   margin-top: 2px;
+}
+
+.rotate {
+  position: absolute;
+  bottom: 8px;
+  right: 8px;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: #008bd2;
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  pointer-events: auto;
+  opacity: 0;
+  transform: scale(0);
+  transition: opacity .3s, transform .3s;
+}
+
+.menu--circle.open .rotate {
+  opacity: 1;
+  transform: scale(1);
 }

--- a/client/src/components/CircleMenu.css
+++ b/client/src/components/CircleMenu.css
@@ -1,7 +1,7 @@
 .menu--circle {
   position: fixed;
   top: 1.5rem;
-  right: 1.5rem;
+  left: 1.5rem;
   width: 220px;
   height: 220px;
   pointer-events: none;
@@ -24,8 +24,8 @@
 
 .icon {
   position: absolute;
-  top: 50%;
-  left: 50%;
+  top: 70%;
+  left: 70%;
   transform: translate(-50%, -50%);
 }
 
@@ -59,12 +59,12 @@
   width: 100%;
   height: 100%;
   border-radius: 50%;
-  transform: scale(0);
+  transform: scale(0.1) rotate(0deg);
   transition: transform .5s;
 }
 
 .menu--circle.open .menu__listings {
-  transform: scale(1);
+  transform: scale(1) rotate(10deg);
 }
 
 .circle {
@@ -117,8 +117,9 @@
 
 .rotate {
   position: absolute;
-  bottom: 8px;
-  right: 8px;
+  top: 8px;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0);
   width: 32px;
   height: 32px;
   border-radius: 50%;
@@ -128,11 +129,10 @@
   cursor: pointer;
   pointer-events: auto;
   opacity: 0;
-  transform: scale(0);
   transition: opacity .3s, transform .3s;
 }
 
 .menu--circle.open .rotate {
   opacity: 1;
-  transform: scale(1);
+  transform: translate(-50%, -50%) scale(1);
 }

--- a/client/src/components/CircleMenu.css
+++ b/client/src/components/CircleMenu.css
@@ -1,10 +1,11 @@
 .menu--circle {
   position: fixed;
   top: 1.5rem;
-  left: 1.5rem;
+  right: 1.5rem;
   width: 220px;
   height: 220px;
   pointer-events: none;
+  --distance: 100px;
 }
 
 .menu__toggle {
@@ -73,6 +74,8 @@
   height: 100%;
   width: 100%;
   position: relative;
+  transform: rotate(var(--rotation, 0deg));
+  transition: transform .5s ease;
 }
 
 .circle li {
@@ -86,12 +89,9 @@
 
 .menu--circle.open .circle li {
   opacity: 1;
-  transform: translate(-50%, -50%) scale(1) rotate(var(--angle)) translate(90px) rotate(calc(var(--angle) * -1));
+  transform: translate(-50%, -50%) scale(1) rotate(var(--angle)) translate(var(--distance,100px)) rotate(calc(var(--angle) * -1));
 }
 
-.circle li:nth-child(1) { --angle: 0deg; }
-.circle li:nth-child(2) { --angle: 30deg; }
-.circle li:nth-child(3) { --angle: 60deg; }
 
 .button {
   background: #fff;

--- a/client/src/components/CircleMenu.css
+++ b/client/src/components/CircleMenu.css
@@ -89,7 +89,10 @@
 
 .menu--circle.open .circle li {
   opacity: 1;
-  transform: translate(-50%, -50%) scale(1) rotate(var(--angle)) translate(var(--distance,100px)) rotate(calc(var(--angle) * -1));
+  transform: translate(-50%, -50%) scale(1)
+    rotate(var(--angle))
+    translate(var(--distance,100px))
+    rotate(calc(var(--angle) * -1 - var(--rotation)));
 }
 
 

--- a/client/src/components/CircleMenu.tsx
+++ b/client/src/components/CircleMenu.tsx
@@ -32,7 +32,7 @@ export default function CircleMenu() {
       <div className="menu__listings">
         <ul className="circle">
           {visible.map((it, i) => (
-            <li key={i} style={{ ['--angle' as any]: `${i * 120}deg` }}>
+            <li key={i} style={{ ['--angle' as any]: `${i * 30}deg` }}>
               <Link to={it.to} className="button">
                 <span>{it.icon}</span>
                 <span className="label">{it.label}</span>

--- a/client/src/components/CircleMenu.tsx
+++ b/client/src/components/CircleMenu.tsx
@@ -5,6 +5,7 @@ import './CircleMenu.css';
 export default function CircleMenu() {
   const [open, setOpen] = useState(false);
   const [index, setIndex] = useState(0);
+  const [rotation, setRotation] = useState(0);
 
   const items = [
     { to: '/manager/create', icon: '➕', label: 'Créer' },
@@ -21,7 +22,7 @@ export default function CircleMenu() {
   ];
 
   return (
-    <div className={`menu menu--circle${open ? ' open' : ''}`}>\
+    <div className={`menu menu--circle${open ? ' open' : ''}`}>
       <button
         className="menu__toggle"
         onClick={() => setOpen(o => !o)}
@@ -30,9 +31,12 @@ export default function CircleMenu() {
         <div className="icon">{open ? '✕' : <div className="hamburger"/>}</div>
       </button>
       <div className="menu__listings">
-        <ul className="circle">
+        <ul
+          className="circle"
+          style={{ ['--rotation' as any]: `${rotation}deg` }}
+        >
           {visible.map((it, i) => (
-            <li key={i} style={{ ['--angle' as any]: `${i * 30}deg` }}>
+            <li key={i} style={{ ['--angle' as any]: `${i * 60}deg` }}>
               <Link to={it.to} className="button">
                 <span>{it.icon}</span>
                 <span className="label">{it.label}</span>
@@ -43,7 +47,10 @@ export default function CircleMenu() {
         <button
           className="rotate"
           aria-label="Tourner"
-          onClick={() => setIndex(n => (n + 1) % items.length)}
+          onClick={() => {
+            setIndex(n => (n + 1) % items.length);
+            setRotation(r => r - 60);
+          }}
         >↻</button>
       </div>
     </div>

--- a/client/src/components/CircleMenu.tsx
+++ b/client/src/components/CircleMenu.tsx
@@ -51,7 +51,7 @@ export default function CircleMenu() {
             setIndex(n => (n + 1) % items.length);
             setRotation(r => r - 60);
           }}
-        >↻</button>
+        >▲</button>
       </div>
     </div>
   );

--- a/client/src/components/CircleMenu.tsx
+++ b/client/src/components/CircleMenu.tsx
@@ -4,7 +4,6 @@ import './CircleMenu.css';
 
 export default function CircleMenu() {
   const [open, setOpen] = useState(false);
-  const [index, setIndex] = useState(0);
   const [rotation, setRotation] = useState(0);
 
   const items = [
@@ -15,11 +14,7 @@ export default function CircleMenu() {
     { to: '/manager/progress', icon: '📊', label: 'Progress' },
   ];
 
-  const visible = [
-    items[index % items.length],
-    items[(index + 1) % items.length],
-    items[(index + 2) % items.length],
-  ];
+  const angleStep = 360 / items.length;
 
   return (
     <div className={`menu menu--circle${open ? ' open' : ''}`}>
@@ -35,8 +30,8 @@ export default function CircleMenu() {
           className="circle"
           style={{ ['--rotation' as any]: `${rotation}deg` }}
         >
-          {visible.map((it, i) => (
-            <li key={i} style={{ ['--angle' as any]: `${i * 60}deg` }}>
+          {items.map((it, i) => (
+            <li key={i} style={{ ['--angle' as any]: `${i * angleStep}deg` }}>
               <Link to={it.to} className="button">
                 <span>{it.icon}</span>
                 <span className="label">{it.label}</span>
@@ -47,10 +42,7 @@ export default function CircleMenu() {
         <button
           className="rotate"
           aria-label="Tourner"
-          onClick={() => {
-            setIndex(n => (n + 1) % items.length);
-            setRotation(r => r - 60);
-          }}
+          onClick={() => setRotation(r => r - angleStep)}
         >▲</button>
       </div>
     </div>

--- a/client/src/components/CircleMenu.tsx
+++ b/client/src/components/CircleMenu.tsx
@@ -43,7 +43,7 @@ export default function CircleMenu() {
           className="rotate"
           aria-label="Tourner"
           onClick={() => setRotation(r => r - angleStep)}
-        >▲</button>
+        >🔄​</button>
       </div>
     </div>
   );

--- a/client/src/components/CircleMenu.tsx
+++ b/client/src/components/CircleMenu.tsx
@@ -1,0 +1,23 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import './CircleMenu.css';
+
+export default function CircleMenu() {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className={`menu menu--circle${open ? ' open' : ''}`}>\
+      <button className="menu__toggle" onClick={() => setOpen(o => !o)} aria-label="Menu">
+        <div className="icon"><div className="hamburger"/></div>
+      </button>
+      <div className="menu__listings">
+        <ul className="circle">
+          <li><Link to="/manager/create" className="button"><span>➕</span><span className="label">Créer</span></Link></li>
+          <li><Link to="/manager/modules" className="button"><span>📝</span><span className="label">Modules</span></Link></li>
+          <li><Link to="/manager/tickets" className="button"><span>📋</span><span className="label">Tickets</span></Link></li>
+          <li><Link to="/manager/checklist-url" className="button"><span>🔗</span><span className="label">Checklist</span></Link></li>
+          <li><Link to="/manager/progress" className="button"><span>📊</span><span className="label">Progress</span></Link></li>
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/CircleMenu.tsx
+++ b/client/src/components/CircleMenu.tsx
@@ -4,19 +4,47 @@ import './CircleMenu.css';
 
 export default function CircleMenu() {
   const [open, setOpen] = useState(false);
+  const [index, setIndex] = useState(0);
+
+  const items = [
+    { to: '/manager/create', icon: '➕', label: 'Créer' },
+    { to: '/manager/modules', icon: '📝', label: 'Modules' },
+    { to: '/manager/tickets', icon: '📋', label: 'Tickets' },
+    { to: '/manager/checklist-url', icon: '🔗', label: 'Checklist' },
+    { to: '/manager/progress', icon: '📊', label: 'Progress' },
+  ];
+
+  const visible = [
+    items[index % items.length],
+    items[(index + 1) % items.length],
+    items[(index + 2) % items.length],
+  ];
+
   return (
     <div className={`menu menu--circle${open ? ' open' : ''}`}>\
-      <button className="menu__toggle" onClick={() => setOpen(o => !o)} aria-label="Menu">
-        <div className="icon"><div className="hamburger"/></div>
+      <button
+        className="menu__toggle"
+        onClick={() => setOpen(o => !o)}
+        aria-label="Menu"
+      >
+        <div className="icon">{open ? '✕' : <div className="hamburger"/>}</div>
       </button>
       <div className="menu__listings">
         <ul className="circle">
-          <li><Link to="/manager/create" className="button"><span>➕</span><span className="label">Créer</span></Link></li>
-          <li><Link to="/manager/modules" className="button"><span>📝</span><span className="label">Modules</span></Link></li>
-          <li><Link to="/manager/tickets" className="button"><span>📋</span><span className="label">Tickets</span></Link></li>
-          <li><Link to="/manager/checklist-url" className="button"><span>🔗</span><span className="label">Checklist</span></Link></li>
-          <li><Link to="/manager/progress" className="button"><span>📊</span><span className="label">Progress</span></Link></li>
+          {visible.map((it, i) => (
+            <li key={i} style={{ ['--angle' as any]: `${i * 120}deg` }}>
+              <Link to={it.to} className="button">
+                <span>{it.icon}</span>
+                <span className="label">{it.label}</span>
+              </Link>
+            </li>
+          ))}
         </ul>
+        <button
+          className="rotate"
+          aria-label="Tourner"
+          onClick={() => setIndex(n => (n + 1) % items.length)}
+        >↻</button>
       </div>
     </div>
   );

--- a/client/src/components/ProgressBar.css
+++ b/client/src/components/ProgressBar.css
@@ -8,9 +8,16 @@
 
 .progress-bar-fill {
   background: linear-gradient(90deg, #0099f7, #043962);
+  background-size: 200% 100%;
+  animation: progress-move 2s linear infinite;
   height: 100%;
   border-radius: 4px;
   transition: width 0.3s ease;
+}
+
+@keyframes progress-move {
+  from { background-position: 0 0; }
+  to { background-position: 200% 0; }
 }
 
 .progress-bar-text {

--- a/client/src/components/ProgressBar.css
+++ b/client/src/components/ProgressBar.css
@@ -9,15 +9,15 @@
 .progress-bar-fill {
   background: linear-gradient(90deg, #0099f7, #043962);
   background-size: 200% 100%;
-  animation: progress-move 2s linear infinite;
+  animation: progress-move 5s linear infinite;
   height: 100%;
   border-radius: 4px;
-  transition: width 0.3s ease;
+  transition: width 0.9s ease;
 }
 
 @keyframes progress-move {
-  from { background-position: 0 0; }
-  to { background-position: 200% 0; }
+  from { background-position: 200% 0; }
+  to { background-position: 0% 0; }
 }
 
 .progress-bar-text {

--- a/client/src/pages/AdminDashboardPage.css
+++ b/client/src/pages/AdminDashboardPage.css
@@ -11,18 +11,18 @@
     
              .admin-dashboard .cards {
                display: flex;
+               flex-direction: column;
                gap: 1rem;
-               flex-wrap: wrap;
                margin-bottom: 1.5rem;
              }
     
              .admin-dashboard .card {
-               flex: 1 1 180px;
                background: #f9f9f9;
                padding: 1rem;
                border-radius: 8px;
                text-align: center;
                box-shadow: 0 1px 3px rgba(0, 0, 0, .1);
+               width: 100%;
              }
     
              .admin-dashboard .big {
@@ -58,9 +58,13 @@
                border-collapse: collapse;
              }
 
-             .admin-dashboard .chart-area {
-               margin-bottom: 2rem;
-             }
+.admin-dashboard .chart-area {
+  margin-bottom: 2rem;
+}
+
+.admin-dashboard .site-info {
+  margin-bottom: 2rem;
+}
     
              .admin-dashboard th,
              .admin-dashboard td {

--- a/client/src/pages/AdminDashboardPage.tsx
+++ b/client/src/pages/AdminDashboardPage.tsx
@@ -121,6 +121,15 @@ import { PieChart, Pie, Cell, Legend, ResponsiveContainer } from 'recharts';
     ];
     const COLORS = ['#043962', '#008bd2', '#00c49f'];
 
+    const siteMap = users.reduce<Record<string, number>>((acc, u) => {
+      const sites = u.role === 'manager' ? (u.sites || []) : [u.site];
+      sites.forEach(s => {
+        if (s) acc[s] = (acc[s] || 0) + 1;
+      });
+      return acc;
+    }, {});
+    const siteData = Object.entries(siteMap).map(([name, value]) => ({ name, value }));
+
      return (
        <div className="admin-dashboard">
          <h1>Tableau de bord admin</h1>
@@ -136,6 +145,20 @@ import { PieChart, Pie, Cell, Legend, ResponsiveContainer } from 'recharts';
             <PieChart>
               <Pie data={roleData} dataKey="value" nameKey="name" outerRadius={80}>
                 {roleData.map((_, i) => (
+                  <Cell key={i} fill={COLORS[i % COLORS.length]} />
+                ))}
+              </Pie>
+              <Legend />
+            </PieChart>
+          </ResponsiveContainer>
+        </section>
+
+        <section className="chart-area">
+          <h3>Répartition par site</h3>
+          <ResponsiveContainer width="100%" height={220}>
+            <PieChart>
+              <Pie data={siteData} dataKey="value" nameKey="name" outerRadius={80} label>
+                {siteData.map((_, i) => (
                   <Cell key={i} fill={COLORS[i % COLORS.length]} />
                 ))}
               </Pie>

--- a/client/src/pages/ManagerDashboardPage.css
+++ b/client/src/pages/ManagerDashboardPage.css
@@ -1,0 +1,50 @@
+.manager-dashboard {
+  padding: 1.5rem;
+  max-width: 960px;
+  margin: auto;
+}
+
+.manager-dashboard h1 {
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.manager-dashboard .cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.manager-dashboard .card {
+  background: #f9f9f9;
+  padding: 1rem;
+  border-radius: 8px;
+  text-align: center;
+  box-shadow: 0 1px 3px rgba(0,0,0,.1);
+  flex: 1;
+  min-width: 250px;
+}
+
+.manager-dashboard .progress-card {
+  margin-bottom: 1.5rem;
+}
+
+.manager-dashboard .big {
+  font-size: 2rem;
+  font-weight: bold;
+  color: #008BD2;
+  margin-top: .5rem;
+}
+
+
+.manager-dashboard table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+.manager-dashboard th,
+.manager-dashboard td {
+  border-bottom: 1px solid #e0e0e0;
+  padding: .5rem .75rem;
+}

--- a/client/src/pages/ManagerDashboardPage.tsx
+++ b/client/src/pages/ManagerDashboardPage.tsx
@@ -2,61 +2,73 @@
    ────────────────────────────────────────── */
    import React, { useEffect, useState } from 'react';
    import { useAuth }   from '../context/AuthContext';
-   import styled        from 'styled-components';
    import { IUser }     from '../api/auth';
-   import { IProgress } from '../api/modules';
-   import { Link }      from 'react-router-dom';
-   import { Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, BarChart } from 'recharts';
+  import { IProgress, IModule, getModules } from '../api/modules';
+  import ProgressBar   from '../components/ProgressBar';
+import { PieChart, Pie, Cell, Legend, ResponsiveContainer } from 'recharts';
+import CircleMenu from '../components/CircleMenu';
+import './ManagerDashboardPage.css';
+const COLORS = ['#043962', '#008bd2', '#00c49f'];
 
    export default function ManagerDashboardPage() {
-     const { user } = useAuth();               // rôle == manager
-     const [caf,setCaf]         = useState<IUser[]>([]);
-     const [prog,setProg]       = useState<IProgress[]>([]);
-     const [loading,setLoading] = useState(true);
+  const { user } = useAuth();               // rôle == manager
+  const [caf,setCaf]         = useState<IUser[]>([]);
+  const [prog,setProg]       = useState<IProgress[]>([]);
+  const [mods,setMods]       = useState<IModule[]>([]);
+  const [loading,setLoading] = useState(true);
 
-     useEffect(()=>{
-       Promise.all([
-         fetch(`/api/users?managerId=${user!.id}`).then(r=>r.json()),
-         fetch(`/api/progress?managerId=${user!.id}`).then(r=>r.json()),
-       ]).then(([u,p])=>{ setCaf(u); setProg(p); })
-         .finally(()=>setLoading(false));
-     },[user]);
+    useEffect(()=>{
+      Promise.all([
+        fetch(`/api/users?managerId=${user!.id}`).then(r=>r.json()),
+        fetch(`/api/progress?managerId=${user!.id}`).then(r=>r.json()),
+        getModules(),
+      ]).then(([u,p,m])=>{ setCaf(u); setProg(p); setMods(m); })
+        .finally(()=>setLoading(false));
+    },[user]);
 
-     /* regroupe par utilisateur */
-     const data = caf.map(c => {
-       const rows = prog.filter(r=>r.username===c.username);
-       const totalVisited = rows.reduce((n,r)=>n+r.visited.length,0);
-       return { name:c.username, visited:totalVisited };
-     });
+    /* répartition par site */
+    const siteMap = caf.reduce<Record<string, number>>((acc, c) => {
+      const site = c.site || '—';
+      acc[site] = (acc[site] || 0) + 1;
+      return acc;
+    }, {});
+    const siteData = Object.entries(siteMap).map(([name, value]) => ({ name, value }));
+
+    /* progression globale */
+    const itemsPerUser = mods.reduce((n,m)=> n + (m.items?.length ?? 0), 0);
+    const totalPossible = itemsPerUser * caf.length;
+    const totalVisited = prog.reduce((n,p)=> n + p.visited.length, 0);
 
      if(loading) return <p style={{padding:'2rem'}}>Chargement…</p>;
 
      return (
-       <Wrapper>
+       <div className="manager-dashboard">
          <h1>Dashboard manager</h1>
 
-         <section className="cards">
-           <StatCard label="CAF gérés" value={caf.length}/>
-           <StatCard label="Modules suivis" value={prog.length}/>
-         </section>
+        <section className="cards">
+          <StatCard label="CAF supervisés" value={caf.length} />
+          <div className="card">
+            <h3>Répartition par site</h3>
+            <ResponsiveContainer width="100%" height={220}>
+              <PieChart>
+                <Pie data={siteData} dataKey="value" nameKey="name" outerRadius={80} label>
+                  {siteData.map((_, i) => (
+                    <Cell key={i} fill={COLORS[i % COLORS.length]} />
+                  ))}
+                </Pie>
+                <Legend />
+              </PieChart>
+            </ResponsiveContainer>
+          </div>
+        </section>
 
-         {/* ----------- actions rapides ----------- */}
-        <div className="quick">
-          <Link to="/manager/create"><button className="btn">+ Créer un compte CAF</button></Link>
-          <Link to="/manager/modules"><button className="btn">📝 Modules</button></Link>
-        <Link to="/manager/tickets"><button className="btn">📋 Tickets</button></Link>
-        <Link to="/manager/checklist-url"><button className="btn">URL Checklist 📋</button></Link>
-        <Link to="/manager/progress"><button className="btn">📊 Progression</button></Link>
+      {/* ----------- actions rapides ----------- */}
+      <CircleMenu />
+
+        <div className="card progress-card">
+          <h3>Avancée globale</h3>
+          <ProgressBar current={totalVisited} total={totalPossible} />
         </div>
-
-         <h2>Progression globale (Items)</h2>
-        <ResponsiveContainer width="100%" height={240}>
-          <BarChart data={data}>
-            <XAxis dataKey="name" /><YAxis allowDecimals={false} />
-            <Tooltip />
-            <Bar dataKey="visited" fill="#008bd2" />
-          </BarChart>
-        </ResponsiveContainer>
 
          <h2>Changer un mot de passe</h2>
          <table>
@@ -72,7 +84,7 @@
              ))}
            </tbody>
          </table>
-       </Wrapper>
+       </div>
      );
 
      async function resetPwd(id:string){
@@ -87,21 +99,6 @@
      }
    }
 
-   const StatCard = ({label,value}:{label:string;value:number})=>(
-     <div className="card"><h3>{label}</h3><p className="big">{value}</p></div>
-   );
-
-   const Wrapper = styled.div`     padding:1.5rem; max-width:960px; margin:auto;
-     .cards{display:flex;gap:1rem;flex-wrap:wrap;margin-bottom:1.5rem}
-     .card{flex:1 1 180px;background:#f9f9f9;padding:1rem;border-radius:8px;
-           text-align:center;box-shadow:0 1px 3px rgba(0,0,0,.1)}
-     .big{font-size:2rem;font-weight:bold;color:#008BD2;margin-top:.5rem}
-   
-     /* ---- actions rapides ---- */
-     .quick{display:flex;gap:1rem;margin-bottom:1rem;flex-wrap:wrap;justify-content:center}
-     .btn{background:#008bd2;color:#fff;border:none;padding:.6rem 1rem;border-radius:4px}
-     .btn:hover{background:#006fa1}
-   
-     table{width:100%;border-collapse:collapse;margin-top:1rem}
-     th,td{border-bottom:1px solid #e0e0e0;padding:.5rem .75rem}
-  `;
+  const StatCard = ({label,value}:{label:string;value:number})=>(
+    <div className="card"><h3>{label}</h3><p className="big">{value}</p></div>
+  );


### PR DESCRIPTION
## Summary
- tweak admin dashboard style to show site distribution
- show site repartition for all accounts in AdminDashboard
- rework ManagerDashboard with site stats, global KPI progress bar and radial quick menu
- replace quick wheel with a CircleMenu component for a more dynamic action hub

## Testing
- `npm --workspace client test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6840386653b88323b8d02414c076e9a5