### PR TITLE
Add item preview feature

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -12,6 +12,7 @@ import ModulePage           from './pages/ModulePage';
 import FavoritesPage        from './pages/FavoritesPage';
 import LoginPage            from './pages/LoginPage';
 import LoggedOutPage        from './pages/LoggedOutPage';
+import PreviewItemPage      from './pages/PreviewItemPage';
 
 import AdminDashboardPage   from './pages/AdminDashboardPage';
 import AdminModulesPage     from './pages/AdminModulesPage';
@@ -40,6 +41,7 @@ function RoleRoutes() {
   if (!user) {
     return (
       <Routes>
+        <Route path="/preview/:moduleId/:itemId" element={<PreviewItemPage />} />
         <Route path="/login"      element={<LoginPage />} />
         <Route path="/logged-out" element={<LoggedOutPage />} />
         <Route path="*"           element={<Navigate to="/login" replace />} />
@@ -51,6 +53,7 @@ function RoleRoutes() {
   if (user.role === 'manager') {
     return (
       <Routes>
+        <Route path="/preview/:moduleId/:itemId" element={<PreviewItemPage />} />
         <Route path="/manager"                     element={<ManagerDashboardPage />} />
         <Route path="/manager/create"              element={<RegisterUserPage />} />
         <Route path="/manager/modules"             element={<AdminModulesPage />} />
@@ -69,6 +72,7 @@ function RoleRoutes() {
   if (user.role === 'admin') {
     return (
       <Routes>
+        <Route path="/preview/:moduleId/:itemId" element={<PreviewItemPage />} />
         <Route path="/admin"                       element={<AdminDashboardPage />} />
         <Route path="/admin/modules"               element={<AdminModulesPage />} />
         <Route path="/admin/modules/:moduleId"     element={<AdminModuleEditor />} />
@@ -87,6 +91,7 @@ function RoleRoutes() {
   /* ---------- user / caf ---------- */
   return (
     <Routes>
+      <Route path="/preview/:moduleId/:itemId" element={<PreviewItemPage />} />
       <Route path="/"                   element={<HomePage />} />
       <Route path="/modules/:moduleId"  element={<ModulePage />} />
       <Route path="/favoris"            element={<FavoritesPage />} />

--- a/client/src/components/ModuleEditor.css
+++ b/client/src/components/ModuleEditor.css
@@ -46,6 +46,18 @@
              button.primary      { background:#008bd2; color:#fff; border:none;
                                    padding:8px 16px; border-radius:4px; cursor:pointer; }
 button.primary:hover{ background:#006fa1; }
+.btn-secondary {
+  background: #043962;
+  color: #ffffff;
+  border: none;
+  padding: 8px 16px;
+  border-radius: 4px;
+  cursor: pointer;
+  text-decoration: none;
+  font-size: .95rem;
+  transition: background .15s;
+}
+.btn-secondary:hover { background:#032c59; }
 .profile-dot{display:inline-block;width:10px;height:10px;border-radius:2px;margin-left:4px;}
 
 /* -------- responsive -------- */

--- a/client/src/components/ModuleEditor.tsx
+++ b/client/src/components/ModuleEditor.tsx
@@ -1,6 +1,7 @@
              /* client/src/components/ModuleEditor.tsx
                 ─────────────────────────────────────── */
 import React, { useMemo, useState, useEffect, forwardRef, useImperativeHandle } from 'react';
+import { Link } from 'react-router-dom';
 import AdvancedEditor                  from './AdvancedEditor';
       
 import {
@@ -498,6 +499,16 @@ const ModuleEditor = forwardRef<ModuleEditorHandle, Props>(
                               />{' '}
                               Item actif
                             </label>
+                            <div style={{ marginTop: 8 }}>
+                              <Link
+                                to={`/preview/${module.id}/${current.id}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="btn-secondary"
+                              >
+                                Prévisualiser
+                              </Link>
+                            </div>
                           </>
                         ) : (
                           <p>Sélectionnez un item dans l’arborescence…</p>

--- a/client/src/pages/PreviewItemPage.css
+++ b/client/src/pages/PreviewItemPage.css
@@ -1,0 +1,20 @@
+.preview-page {
+  padding: 1rem;
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.preview-page .btn-back {
+  background: none;
+  border: none;
+  color: #043962;
+  font-size: 1rem;
+  cursor: pointer;
+  padding: 6px 8px;
+  border-radius: 4px;
+  transition: background .15s;
+}
+
+.preview-page .btn-back:hover {
+  background: #e9f2ff;
+}

--- a/client/src/pages/PreviewItemPage.tsx
+++ b/client/src/pages/PreviewItemPage.tsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import ItemContent from '../components/ItemContent';
+import { getItem, getModule, IItem, IModule } from '../api/modules';
+import './PreviewItemPage.css';
+
+export default function PreviewItemPage() {
+  const { moduleId, itemId } = useParams<{ moduleId: string; itemId: string }>();
+  const navigate = useNavigate();
+  const [mod, setMod] = useState<IModule | null>(null);
+  const [item, setItem] = useState<IItem | null>(null);
+
+  useEffect(() => {
+    if (!moduleId || !itemId) return;
+    getModule(moduleId).then(setMod).catch(() => setMod(null));
+    getItem(moduleId, itemId).then(setItem).catch(() => setItem(null));
+  }, [moduleId, itemId]);
+
+  if (!mod || !item) return <p style={{ padding: '2rem' }}>Chargement…</p>;
+
+  return (
+    <div className="preview-page">
+      <button className="btn-back" onClick={() => navigate(-1)}>← Retour éditeur</button>
+      <h2>{mod.title} – aperçu de « {item.title} »</h2>
+      <ItemContent
+        title={item.title}
+        subtitle={item.subtitle}
+        description={item.content}
+        links={item.links}
+        images={item.images}
+        videos={item.videos}
+        quiz={item.quiz}
+        moduleId={mod.id}
+        itemId={item.id}
+        needValidation={item.needValidation}
+        status="new"
+        onStatusChange={() => undefined}
+        isFav={false}
+        onToggleFav={() => undefined}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement a page to preview an item
- add "Prévisualiser" button in module editor
- create styles for preview page and secondary buttons
- expose preview route for all users

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684abc9b6c9c8323b69fc19958b8dd0f