### PR TITLE
Add interactive startup choice

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,9 +34,12 @@
                 "@tiptap/starter-kit": "^2.12.0",
                 "@tiptap/suggestion": "^2.12.0",
                 "canvas-confetti": "^1.9.3",
+                "figlet": "^1.6.0",
                 "highlight.js": "^11.11.1",
                 "lowlight": "^3.3.0",
                 "lucide-react": "^0.511.0",
+                "open": "^8.4.0",
+                "ora": "^5.0.0",
                 "quill": "^2.0.3",
                 "react": "^18.3.1",
                 "react-dom": "^18.3.1",
@@ -7042,6 +7045,26 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "license": "MIT"
         },
+        "node_modules/base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/batch": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -7097,6 +7120,17 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/bl": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+            "license": "MIT",
+            "dependencies": {
+                "buffer": "^5.5.0",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.4.0"
             }
         },
         "node_modules/bluebird": {
@@ -7212,6 +7246,30 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "node-int64": "^0.4.0"
+            }
+        },
+        "node_modules/buffer": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
             }
         },
         "node_modules/buffer-from": {
@@ -7533,6 +7591,30 @@
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/cli-cursor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+            "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+            "license": "MIT",
+            "dependencies": {
+                "restore-cursor": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cli-spinners": {
+            "version": "2.9.2",
+            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+            "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/cliui": {
@@ -8687,6 +8769,27 @@
             },
             "engines": {
                 "node": ">= 10"
+            }
+        },
+        "node_modules/defaults": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+            "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+            "license": "MIT",
+            "dependencies": {
+                "clone": "^1.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/defaults/node_modules/clone": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+            "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8"
             }
         },
         "node_modules/define-data-property": {
@@ -10348,6 +10451,18 @@
                 }
             }
         },
+        "node_modules/figlet": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.8.1.tgz",
+            "integrity": "sha512-kEC3Sme+YvA8Hkibv0NR1oClGcWia0VB2fC1SlMy027cwe795Xx40Xiv/nw/iFAwQLupymWh+uhAAErn/7hwPg==",
+            "license": "MIT",
+            "bin": {
+                "figlet": "bin/index.js"
+            },
+            "engines": {
+                "node": ">= 0.4.0"
+            }
+        },
         "node_modules/file-entry-cache": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -11622,6 +11737,26 @@
                 "node": ">=4"
             }
         },
+        "node_modules/ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "BSD-3-Clause"
+        },
         "node_modules/ignore": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -11997,6 +12132,15 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-interactive": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+            "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/is-map": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -12216,6 +12360,18 @@
             "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
             "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
             "license": "MIT"
+        },
+        "node_modules/is-unicode-supported": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+            "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/is-weakmap": {
             "version": "2.0.2",
@@ -13855,6 +14011,22 @@
             "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
             "license": "MIT"
         },
+        "node_modules/log-symbols": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+            "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^4.1.0",
+                "is-unicode-supported": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/loose-envify": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -14689,6 +14861,29 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/ora": {
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+            "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+            "license": "MIT",
+            "dependencies": {
+                "bl": "^4.1.0",
+                "chalk": "^4.1.0",
+                "cli-cursor": "^3.1.0",
+                "cli-spinners": "^2.5.0",
+                "is-interactive": "^1.0.0",
+                "is-unicode-supported": "^0.1.0",
+                "log-symbols": "^4.1.0",
+                "strip-ansi": "^6.0.0",
+                "wcwidth": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/orderedmap": {
@@ -17559,6 +17754,19 @@
                 "node": ">=10"
             }
         },
+        "node_modules/restore-cursor": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+            "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+            "license": "MIT",
+            "dependencies": {
+                "onetime": "^5.1.0",
+                "signal-exit": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/retry": {
             "version": "0.13.1",
             "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -20357,6 +20565,15 @@
             "license": "MIT",
             "dependencies": {
                 "minimalistic-assert": "^1.0.0"
+            }
+        },
+        "node_modules/wcwidth": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+            "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+            "license": "MIT",
+            "dependencies": {
+                "defaults": "^1.0.3"
             }
         },
         "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "scripts": {
         "start:backend": "npm --workspace backend start",
         "start:client": "npm --workspace client start",
-        "start": "concurrently \"npm run start:backend\" \"npm run start:client\""
+        "start:combined": "concurrently \"npm run start:backend\" \"npm run start:client\"",
+        "start": "node scripts/start.js"
     },
     "devDependencies": {
         "@types/highlight.js": "^10.1.0",
@@ -49,6 +50,9 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-icons": "^4.3.1",
-        "react-quill": "^2.0.0"
+        "react-quill": "^2.0.0",
+        "figlet": "^1.6.0",
+        "ora": "^5.0.0",
+        "open": "^8.4.0"
     }
 }

--- a/scripts/logo.txt
+++ b/scripts/logo.txt
@@ -1,0 +1,27 @@
+                                                                NN              
+                                                            NNNNNN              
+                                                        NNNNNNNNN               
+                                                         NNNNNNNN               
+                                                         NNNNNNN                
+                 NNNNNNNNNNN         NNNNNN            NNNNN  NN                
+               NNNNNNNNNNNNNNN      NNNNNNNN         NNNNN                      
+             NNNNNNN     NNNN       NNNNNNNNN       NNNN                        
+            NNNNNN                 NNNNN NNNNN    NNNN  NNNNNNNNNNNN            
+            NNNNNNN               NNNNN  NNNNN  NNNNN   NNNNNNNNNNNN            
+            NNNN N               NNNNN    NNNNN NNN     NNNNNNNNNNNN            
+            NNNN N               NNNNN     NNNNN        NNNNN                   
+            NNNNN N             NNNNNNNNNNNNNNNNN       NNNNNNNNNNN             
+             NNNNN NN     NN   NNNNNNNNNNNNNNNNNN       NNNNNNNNNNN             
+              NNNNNNNNNNNNNNN NNNNNN         NNNNN      NNNNNNNNNNN             
+               NNNNNNNNNNNNNN NNNNN          NNNNNN     NNNNN                   
+                  NNNNNNNN   NNNNN            NNNNNN    NNNNN                   
+                                                        NNNNN                   
+                                                                                
+                                                                                
+             NNNNNN  NNNN       NN     NN  NN    NN  NNNNNN  NNNN               
+               NN    NN  NN    NNNN    NN  NNN   NN  NN      NN  NN             
+               NN    NN  NN   NN NN    NN  NNNN  NN  NNNNN   NN  NN             
+               NN    NNNNN    NNNNNN   NN  NN NNNNN  NN      NNNNN              
+               NN    NN  NN  NN    NN  NN  NN   NNN  NNNNNN  NN  NN             
+
+               

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -5,7 +5,7 @@ const ora = require('ora');
 const open = require('open');
 
 function ascii(text) {
-  return figlet.textSync(text, { font: 'Standard' });
+  return figlet.textSync(text, { font: 'Slant' });
 }
 
 console.log(ascii('CAF Trainer'));
@@ -31,8 +31,8 @@ rl.question('Voulez-vous les logs ? (o/n) ', answer => {
     if (!opened && str.includes('Compiled successfully')) {
       opened = true;
       spinner.stop();
-      console.log('\n' + ascii('Operationnel'));
-      open('http://localhost:3000');
+      console.log('Opérationnel sur http://localhost:3000');
+      
     }
   });
 });

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -1,0 +1,38 @@
+const readline = require('readline');
+const { spawn } = require('child_process');
+const figlet = require('figlet');
+const ora = require('ora');
+const open = require('open');
+
+function ascii(text) {
+  return figlet.textSync(text, { font: 'Standard' });
+}
+
+console.log(ascii('CAF Trainer'));
+
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+rl.question('Voulez-vous les logs ? (o/n) ', answer => {
+  rl.close();
+  const wantLogs = answer.trim().toLowerCase() === 'o';
+
+  if (wantLogs) {
+    spawn('npm', ['run', 'start:combined'], { stdio: 'inherit', shell: true });
+    return;
+  }
+
+  const spinner = ora('Compilation en cours...').start();
+
+  const backend = spawn('npm', ['--workspace', 'backend', 'start'], { shell: true, stdio: 'ignore' });
+  const client = spawn('npm', ['--workspace', 'client', 'start'], { shell: true, stdio: ['ignore', 'pipe', 'pipe'] });
+
+  let opened = false;
+  client.stdout.on('data', data => {
+    const str = data.toString();
+    if (!opened && str.includes('Compiled successfully')) {
+      opened = true;
+      spinner.stop();
+      console.log('\n' + ascii('Operationnel'));
+      open('http://localhost:3000');
+    }
+  });
+});

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -3,12 +3,22 @@ const { spawn } = require('child_process');
 const figlet = require('figlet');
 const ora = require('ora');
 const open = require('open');
+const path = require('path');
+const fs = require('fs');
+
+
+const logoPath = path.join(__dirname, 'logo.txt');
+try {
+  const logo = fs.readFileSync(logoPath, 'utf8');
+  console.log(logo);
+} catch (err) {
+  console.error('Unable to read logo:', err);
+}
 
 function ascii(text) {
   return figlet.textSync(text, { font: 'Slant' });
 }
 
-console.log(ascii('CAF Trainer'));
 
 const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
 rl.question('Voulez-vous les logs ? (o/n) ', answer => {
@@ -31,8 +41,8 @@ rl.question('Voulez-vous les logs ? (o/n) ', answer => {
     if (!opened && str.includes('Compiled successfully')) {
       opened = true;
       spinner.stop();
-      console.log('Opérationnel sur http://localhost:3000');
-      
+      console.log('\n' + ascii('- Opérationnel -') +'\n'+'\n'+'You can now view CAF-Trainer in the browser.');
+      console.log('Local:            http://localhost:3000')
     }
   });
 });


### PR DESCRIPTION
## Summary
- provide a new `start.js` script prompting to display logs or not
- hook the script from `npm start`
- keep old behaviour in `start:combined`
- add figlet, ora and open dependencies for ascii art and loader

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ecfc415488323babafbcd7a2fb4e2