### PR TITLE
Add dynamic data directory configuration

### DIFF
--- a/.env
+++ b/.env
@@ -2,4 +2,8 @@ MAIL_USER=services@conforea.fr
 MAIL_PASS=Test2025!
 PORT=5000
 JWT_SECRET=MaCleSuperSecrète
-DATA_DIR=./src/data
+DATA_DIR=./backend/src/data
+IMAGE_DIR=./backend/image
+VIDEO_DIR=./backend/video
+ARCHIVE_DIR=./backend/src/archive
+

--- a/.env
+++ b/.env
@@ -5,5 +5,5 @@ JWT_SECRET=MaCleSuperSecrète
 DATA_DIR=./backend/src/data
 IMAGE_DIR=./backend/image
 VIDEO_DIR=./backend/video
-ARCHIVE_DIR=./backend/src/archive
+ARCHIVE_DIR=./backend/archive
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 client/build
+
+archive/

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ npm start          # demarre le serveur et l'appli React
 
 `setup-env.js` vous demande la lettre du lecteur et le dossier racine dans
 lequel seront ecrites toutes les donnees (JSON, images, videos et archives).
+Si vous indiquez la lettre `C`, le chemin est base sur votre variable
+d'environnement `%USERPROFILE%` pour enregistrer les fichiers dans votre
+repertoire utilisateur.
 
 Le script `npm start` fait appel a `scripts/start.js`. Ce dernier propose de
 lancer les deux processus (serveur et client) en mode "verbose" pour afficher les
@@ -151,10 +154,10 @@ JWT_SECRET=MaCleSuperSecrete
 DATA_DIR=./backend/src/data
 IMAGE_DIR=./backend/image
 VIDEO_DIR=./backend/video
-ARCHIVE_DIR=./backend/src/archive
+ARCHIVE_DIR=./backend/archive
 ```
 
-`MAIL_USER` et `MAIL_PASS` servent a l'envoi de mails automatiques (notifications et alertes). `PORT` indique sur quel port demarre Express. `JWT_SECRET` est prevu pour de futures evolutions utilisant JSON Web Tokens. `DATA_DIR`, `IMAGE_DIR`, `VIDEO_DIR` et `ARCHIVE_DIR` definissent les emplacements des donnees, images, videos et archives. Vous pouvez facilement les modifier via le script `setup-env.js`.
+`MAIL_USER` et `MAIL_PASS` servent a l'envoi de mails automatiques (notifications et alertes). `PORT` indique sur quel port demarre Express. `JWT_SECRET` est prevu pour de futures evolutions utilisant JSON Web Tokens. `DATA_DIR`, `IMAGE_DIR`, `VIDEO_DIR` et `ARCHIVE_DIR` definissent les emplacements des donnees, images, videos et archives. Le script `setup-env.js` permet de les reconfigurer et place les fichiers dans `%USERPROFILE%` si vous choisissez la lettre `C`.
 
 ## 5. Conseils de developpement
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ npm run setup-env  # configure les chemins des fichiers
 npm start          # demarre le serveur et l'appli React
 ```
 
-`setup-env.js` vous demande la lettre du lecteur et le dossier racine dans
-lequel seront ecrites toutes les donnees (JSON, images, videos et archives).
-Si vous indiquez la lettre `C`, le chemin est base sur votre variable
-d'environnement `%USERPROFILE%` pour enregistrer les fichiers dans votre
-repertoire utilisateur.
+`setup-env.js` vous propose d'utiliser les chemins locaux du projet ou de
+rediger ces donnees dans un emplacement centralise. Si vous choisissez cette
+deuxieme option, il suffit d'indiquer la lettre du lecteur. Le dossier
+`CAF-Trainer` y sera cree automatiquement. Avec la lettre `C`, les fichiers sont
+places sous `%USERPROFILE%\CAF-Trainer`.
 
 Le script `npm start` fait appel a `scripts/start.js`. Ce dernier propose de
 lancer les deux processus (serveur et client) en mode "verbose" pour afficher les
@@ -157,7 +157,7 @@ VIDEO_DIR=./backend/video
 ARCHIVE_DIR=./backend/archive
 ```
 
-`MAIL_USER` et `MAIL_PASS` servent a l'envoi de mails automatiques (notifications et alertes). `PORT` indique sur quel port demarre Express. `JWT_SECRET` est prevu pour de futures evolutions utilisant JSON Web Tokens. `DATA_DIR`, `IMAGE_DIR`, `VIDEO_DIR` et `ARCHIVE_DIR` definissent les emplacements des donnees, images, videos et archives. Le script `setup-env.js` permet de les reconfigurer et place les fichiers dans `%USERPROFILE%` si vous choisissez la lettre `C`.
+`MAIL_USER` et `MAIL_PASS` servent a l'envoi de mails automatiques (notifications et alertes). `PORT` indique sur quel port demarre Express. `JWT_SECRET` est prevu pour de futures evolutions utilisant JSON Web Tokens. `DATA_DIR`, `IMAGE_DIR`, `VIDEO_DIR` et `ARCHIVE_DIR` pointent par defaut vers le projet. Le script `setup-env.js` peut les rediriger vers un lecteur de votre choix : il suffit de renseigner la lettre desiree et le dossier `CAF-Trainer` sera utilise (avec `%USERPROFILE%` pour la lettre `C`).
 
 ## 5. Conseils de developpement
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,12 @@ l'architecture du projet et son fonctionnement.
 
 ```bash
 npm install        # installe les dependances de tous les workspaces
+npm run setup-env  # configure les chemins des fichiers
 npm start          # demarre le serveur et l'appli React
 ```
+
+`setup-env.js` vous demande la lettre du lecteur et le dossier racine dans
+lequel seront ecrites toutes les donnees (JSON, images, videos et archives).
 
 Le script `npm start` fait appel a `scripts/start.js`. Ce dernier propose de
 lancer les deux processus (serveur et client) en mode "verbose" pour afficher les
@@ -144,10 +148,13 @@ MAIL_USER=services@conforea.fr
 MAIL_PASS=Test2025!
 PORT=5000
 JWT_SECRET=MaCleSuperSecrete
-DATA_DIR=./src/data
+DATA_DIR=./backend/src/data
+IMAGE_DIR=./backend/image
+VIDEO_DIR=./backend/video
+ARCHIVE_DIR=./backend/src/archive
 ```
 
-`MAIL_USER` et `MAIL_PASS` servent a l'envoi de mails automatiques (notifications et alertes). `PORT` indique sur quel port demarre Express. `JWT_SECRET` est prevu pour de futures evolutions utilisant JSON Web Tokens. Enfin, `DATA_DIR` precise l'emplacement des fichiers JSON si vous souhaitez en changer.
+`MAIL_USER` et `MAIL_PASS` servent a l'envoi de mails automatiques (notifications et alertes). `PORT` indique sur quel port demarre Express. `JWT_SECRET` est prevu pour de futures evolutions utilisant JSON Web Tokens. `DATA_DIR`, `IMAGE_DIR`, `VIDEO_DIR` et `ARCHIVE_DIR` definissent les emplacements des donnees, images, videos et archives. Vous pouvez facilement les modifier via le script `setup-env.js`.
 
 ## 5. Conseils de developpement
 

--- a/backend/.env
+++ b/backend/.env
@@ -3,3 +3,7 @@ MAIL_PASS=Test2025!
 PORT=5000
 JWT_SECRET=MaCleSuperSecrète
 DATA_DIR=./src/data
+IMAGE_DIR=../image
+VIDEO_DIR=../video
+ARCHIVE_DIR=./src/archive
+

--- a/backend/.env
+++ b/backend/.env
@@ -5,5 +5,5 @@ JWT_SECRET=MaCleSuperSecrète
 DATA_DIR=./src/data
 IMAGE_DIR=../image
 VIDEO_DIR=../video
-ARCHIVE_DIR=./src/archive
+ARCHIVE_DIR=../archive
 

--- a/backend/dist/config/dataStore.js
+++ b/backend/dist/config/dataStore.js
@@ -6,7 +6,10 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.write = exports.read = void 0;
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
-const DATA_DIR = path_1.default.resolve(__dirname, '..', 'data');
+// Permet de rediriger les fichiers JSON via la variable d'environnement DATA_DIR
+const DATA_DIR = process.env.DATA_DIR
+    ? path_1.default.resolve(process.env.DATA_DIR)
+    : path_1.default.resolve(__dirname, '..', 'data');
 function read(name) {
     const file = path_1.default.join(DATA_DIR, `${name}.json`);
     if (!fs_1.default.existsSync(file)) {

--- a/backend/dist/index.js
+++ b/backend/dist/index.js
@@ -28,12 +28,16 @@ const alert_1 = __importDefault(require("./routes/alert"));
 const settings_1 = __importDefault(require("./routes/settings"));
 const app = (0, express_1.default)();
 const PORT = process.env.PORT || 5000;
-const IMG_DIR = path_1.default.resolve(__dirname, '../image');
+const IMG_DIR = process.env.IMAGE_DIR
+    ? path_1.default.resolve(process.env.IMAGE_DIR)
+    : path_1.default.resolve(__dirname, '../image');
 if (!fs_1.default.existsSync(IMG_DIR))
-    fs_1.default.mkdirSync(IMG_DIR);
-const VID_DIR = path_1.default.resolve(__dirname, '../video');
+    fs_1.default.mkdirSync(IMG_DIR, { recursive: true });
+const VID_DIR = process.env.VIDEO_DIR
+    ? path_1.default.resolve(process.env.VIDEO_DIR)
+    : path_1.default.resolve(__dirname, '../video');
 if (!fs_1.default.existsSync(VID_DIR))
-    fs_1.default.mkdirSync(VID_DIR);
+    fs_1.default.mkdirSync(VID_DIR, { recursive: true });
 app.use((0, cors_1.default)());
 app.use(express_1.default.json({ limit: '200mb' }));
 app.use('/images', express_1.default.static(IMG_DIR));

--- a/backend/dist/routes/images.js
+++ b/backend/dist/routes/images.js
@@ -8,9 +8,11 @@ const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
 const router = (0, express_1.Router)();
 // Stocke les images dans le même dossier que celui exposé par index.ts
-const DIR = path_1.default.resolve(__dirname, '../..', 'image');
+const DIR = process.env.IMAGE_DIR
+    ? path_1.default.resolve(process.env.IMAGE_DIR)
+    : path_1.default.resolve(__dirname, '../..', 'image');
 if (!fs_1.default.existsSync(DIR))
-    fs_1.default.mkdirSync(DIR);
+    fs_1.default.mkdirSync(DIR, { recursive: true });
 router.post('/', (req, res) => {
     const { data } = req.body;
     if (!data)

--- a/backend/dist/routes/videos.js
+++ b/backend/dist/routes/videos.js
@@ -8,9 +8,11 @@ const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
 const router = (0, express_1.Router)();
 // Stocke les vidéos dans le même dossier que celui exposé par index.ts
-const DIR = path_1.default.resolve(__dirname, '../..', 'video');
+const DIR = process.env.VIDEO_DIR
+    ? path_1.default.resolve(process.env.VIDEO_DIR)
+    : path_1.default.resolve(__dirname, '../..', 'video');
 if (!fs_1.default.existsSync(DIR))
-    fs_1.default.mkdirSync(DIR);
+    fs_1.default.mkdirSync(DIR, { recursive: true });
 router.post('/', (req, res) => {
     const { data } = req.body;
     if (!data)

--- a/backend/src/config/dataStore.ts
+++ b/backend/src/config/dataStore.ts
@@ -1,7 +1,10 @@
 import fs from 'fs';
 import path from 'path';
 
-const DATA_DIR = path.resolve(__dirname, '..', 'data');
+// Permet de rediriger les fichiers JSON via la variable d'environnement DATA_DIR
+const DATA_DIR = process.env.DATA_DIR
+  ? path.resolve(process.env.DATA_DIR)
+  : path.resolve(__dirname, '..', 'data');
 
 export function read<T = any>(name: string): T[] {
     const file = path.join(DATA_DIR, `${name}.json`);

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -28,10 +28,14 @@ import settingsRouter from './routes/settings';
 const app = express();
 const PORT = process.env.PORT || 5000;
 
-const IMG_DIR = path.resolve(__dirname, '../image');
-if (!fs.existsSync(IMG_DIR)) fs.mkdirSync(IMG_DIR);
-const VID_DIR = path.resolve(__dirname, '../video');
-if (!fs.existsSync(VID_DIR)) fs.mkdirSync(VID_DIR);
+const IMG_DIR = process.env.IMAGE_DIR
+  ? path.resolve(process.env.IMAGE_DIR)
+  : path.resolve(__dirname, '../image');
+if (!fs.existsSync(IMG_DIR)) fs.mkdirSync(IMG_DIR, { recursive: true });
+const VID_DIR = process.env.VIDEO_DIR
+  ? path.resolve(process.env.VIDEO_DIR)
+  : path.resolve(__dirname, '../video');
+if (!fs.existsSync(VID_DIR)) fs.mkdirSync(VID_DIR, { recursive: true });
 
 app.use(cors());
 app.use(express.json({ limit: '200mb' }));

--- a/backend/src/routes/images.ts
+++ b/backend/src/routes/images.ts
@@ -4,9 +4,11 @@ import path from 'path';
 
 const router = Router();
 // Stocke les images dans le même dossier que celui exposé par index.ts
-const DIR = path.resolve(__dirname, '../..', 'image');
+const DIR = process.env.IMAGE_DIR
+  ? path.resolve(process.env.IMAGE_DIR)
+  : path.resolve(__dirname, '../..', 'image');
 
-if (!fs.existsSync(DIR)) fs.mkdirSync(DIR);
+if (!fs.existsSync(DIR)) fs.mkdirSync(DIR, { recursive: true });
 
 router.post('/', (req, res) => {
   const { data } = req.body as { data?: string };

--- a/backend/src/routes/videos.ts
+++ b/backend/src/routes/videos.ts
@@ -4,9 +4,11 @@ import path from 'path';
 
 const router = Router();
 // Stocke les vidéos dans le même dossier que celui exposé par index.ts
-const DIR = path.resolve(__dirname, '../..', 'video');
+const DIR = process.env.VIDEO_DIR
+  ? path.resolve(process.env.VIDEO_DIR)
+  : path.resolve(__dirname, '../..', 'video');
 
-if (!fs.existsSync(DIR)) fs.mkdirSync(DIR);
+if (!fs.existsSync(DIR)) fs.mkdirSync(DIR, { recursive: true });
 
 router.post('/', (req, res) => {
   const { data } = req.body as { data?: string };

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
         "start:combined": "concurrently \"npm run start:backend\" \"npm run start:client\"",
         "prestart": "node scripts/rgpdCleanup.js && node scripts/fixSessions.js",
         "start": "node scripts/start.js",
-        "fix:sessions": "node scripts/fixSessions.js"
+        "fix:sessions": "node scripts/fixSessions.js",
+        "setup-env": "node setup-env.js"
     },
     "devDependencies": {
         "@types/highlight.js": "^10.1.0",

--- a/scripts/fixSessions.js
+++ b/scripts/fixSessions.js
@@ -1,7 +1,10 @@
 const fs = require('fs');
 const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '../backend/.env') });
 
-const FILE = path.join(__dirname, '../backend/src/data/analytics.json');
+const FILE = process.env.DATA_DIR
+  ? path.join(path.resolve(process.env.DATA_DIR), 'analytics.json')
+  : path.join(__dirname, '../backend/src/data/analytics.json');
 
 function load() {
   try {

--- a/scripts/rgpdCleanup.js
+++ b/scripts/rgpdCleanup.js
@@ -1,9 +1,14 @@
 
 const fs = require('fs');
 const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '../backend/.env') });
 
-const DATA_DIR = path.join(__dirname, '../backend/src/data');
-const ARCHIVE_DIR = path.join(__dirname, '../backend/archive');
+const DATA_DIR = process.env.DATA_DIR
+  ? path.resolve(process.env.DATA_DIR)
+  : path.join(__dirname, '../backend/src/data');
+const ARCHIVE_DIR = process.env.ARCHIVE_DIR
+  ? path.resolve(process.env.ARCHIVE_DIR)
+  : path.join(__dirname, '../backend/archive');
 
 if (!fs.existsSync(ARCHIVE_DIR)) fs.mkdirSync(ARCHIVE_DIR, { recursive: true });
 

--- a/setup-env.js
+++ b/setup-env.js
@@ -14,13 +14,19 @@ function ask(question) {
   const drive = (driveInput || 'C').trim().replace(/[^a-zA-Z]/g, '').toUpperCase();
   const folder = (folderInput || 'CAF-Trainer').trim() || 'CAF-Trainer';
 
-  const rootPath = `${drive}:\\${folder}`;
+  let rootPath;
+  if (drive === 'C') {
+    const base = process.env.USERPROFILE || `${drive}:\\Users\\Default`;
+    rootPath = path.join(base, folder);
+  } else {
+    rootPath = `${drive}:\\${folder}`;
+  }
 
   const envUpdates = {
     DATA_DIR: `${rootPath}\\backend\\src\\data`,
     IMAGE_DIR: `${rootPath}\\backend\\image`,
     VIDEO_DIR: `${rootPath}\\backend\\video`,
-    ARCHIVE_DIR: `${rootPath}\\backend\\src\\archive`,
+    ARCHIVE_DIR: `${rootPath}\\backend\\archive`,
   };
 
   const envFiles = [path.join(__dirname, '.env'), path.join(__dirname, 'backend', '.env')];

--- a/setup-env.js
+++ b/setup-env.js
@@ -7,31 +7,52 @@ function ask(question) {
   return new Promise(resolve => rl.question(question, answer => { rl.close(); resolve(answer); }));
 }
 
-(async () => {
-  const driveInput = await ask('Lettre du lecteur cible (ex: C): ');
-  const folderInput = await ask('Nom du dossier principal (CAF-Trainer par defaut): ');
+async function main() {
+  const localInput = await ask('Utiliser les chemins locaux du projet ? (O/n) ');
+  const useLocal = !localInput || localInput.trim().toLowerCase().startsWith('o');
 
-  const drive = (driveInput || 'C').trim().replace(/[^a-zA-Z]/g, '').toUpperCase();
-  const folder = (folderInput || 'CAF-Trainer').trim() || 'CAF-Trainer';
+  let rootUpdates;
+  let backendUpdates;
 
-  let rootPath;
-  if (drive === 'C') {
-    const base = process.env.USERPROFILE || `${drive}:\\Users\\Default`;
-    rootPath = path.join(base, folder);
+  if (useLocal) {
+    rootUpdates = {
+      DATA_DIR: './backend/src/data',
+      IMAGE_DIR: './backend/image',
+      VIDEO_DIR: './backend/video',
+      ARCHIVE_DIR: './backend/archive',
+    };
+    backendUpdates = {
+      DATA_DIR: './src/data',
+      IMAGE_DIR: '../image',
+      VIDEO_DIR: '../video',
+      ARCHIVE_DIR: '../archive',
+    };
   } else {
-    rootPath = `${drive}:\\${folder}`;
+    const driveInput = await ask('Lettre du lecteur cible (ex: C): ');
+    const drive = (driveInput || 'C').trim().replace(/[^a-zA-Z]/g, '').toUpperCase();
+    let rootPath;
+    if (drive === 'C') {
+      const base = process.env.USERPROFILE || `${drive}:\\Users\\Default`;
+      rootPath = path.join(base, 'CAF-Trainer');
+    } else {
+      rootPath = `${drive}:\\CAF-Trainer`;
+    }
+    const abs = {
+      DATA_DIR: `${rootPath}\\backend\\src\\data`,
+      IMAGE_DIR: `${rootPath}\\backend\\image`,
+      VIDEO_DIR: `${rootPath}\\backend\\video`,
+      ARCHIVE_DIR: `${rootPath}\\backend\\archive`,
+    };
+    rootUpdates = abs;
+    backendUpdates = abs;
   }
 
-  const envUpdates = {
-    DATA_DIR: `${rootPath}\\backend\\src\\data`,
-    IMAGE_DIR: `${rootPath}\\backend\\image`,
-    VIDEO_DIR: `${rootPath}\\backend\\video`,
-    ARCHIVE_DIR: `${rootPath}\\backend\\archive`,
-  };
+  const envFiles = [
+    { file: path.join(__dirname, '.env'), updates: rootUpdates },
+    { file: path.join(__dirname, 'backend', '.env'), updates: backendUpdates },
+  ];
 
-  const envFiles = [path.join(__dirname, '.env'), path.join(__dirname, 'backend', '.env')];
-
-  for (const file of envFiles) {
+  for (const { file, updates } of envFiles) {
     let content = '';
     if (fs.existsSync(file)) content = fs.readFileSync(file, 'utf8');
     const lines = content.split(/\r?\n/).filter(Boolean);
@@ -40,9 +61,11 @@ function ask(question) {
       const m = line.match(/^([^=]+)=(.*)$/);
       if (m) env[m[1]] = m[2];
     }
-    Object.assign(env, envUpdates);
+    Object.assign(env, updates);
     const newContent = Object.entries(env).map(([k,v]) => `${k}=${v}`).join('\n');
     fs.writeFileSync(file, newContent);
     console.log(`Mis a jour: ${file}`);
   }
-})();
+}
+
+main();

--- a/setup-env.js
+++ b/setup-env.js
@@ -2,6 +2,11 @@ const fs = require('fs');
 const path = require('path');
 const readline = require('readline');
 
+if (process.env.NODE_EXTRA_CA_CERTS &&
+    !fs.existsSync(process.env.NODE_EXTRA_CA_CERTS)) {
+  delete process.env.NODE_EXTRA_CA_CERTS;
+}
+
 function ask(question) {
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
   return new Promise(resolve => rl.question(question, answer => { rl.close(); resolve(answer); }));

--- a/setup-env.js
+++ b/setup-env.js
@@ -1,0 +1,42 @@
+const fs = require('fs');
+const path = require('path');
+const readline = require('readline');
+
+function ask(question) {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise(resolve => rl.question(question, answer => { rl.close(); resolve(answer); }));
+}
+
+(async () => {
+  const driveInput = await ask('Lettre du lecteur cible (ex: C): ');
+  const folderInput = await ask('Nom du dossier principal (CAF-Trainer par defaut): ');
+
+  const drive = (driveInput || 'C').trim().replace(/[^a-zA-Z]/g, '').toUpperCase();
+  const folder = (folderInput || 'CAF-Trainer').trim() || 'CAF-Trainer';
+
+  const rootPath = `${drive}:\\${folder}`;
+
+  const envUpdates = {
+    DATA_DIR: `${rootPath}\\backend\\src\\data`,
+    IMAGE_DIR: `${rootPath}\\backend\\image`,
+    VIDEO_DIR: `${rootPath}\\backend\\video`,
+    ARCHIVE_DIR: `${rootPath}\\backend\\src\\archive`,
+  };
+
+  const envFiles = [path.join(__dirname, '.env'), path.join(__dirname, 'backend', '.env')];
+
+  for (const file of envFiles) {
+    let content = '';
+    if (fs.existsSync(file)) content = fs.readFileSync(file, 'utf8');
+    const lines = content.split(/\r?\n/).filter(Boolean);
+    const env = {};
+    for (const line of lines) {
+      const m = line.match(/^([^=]+)=(.*)$/);
+      if (m) env[m[1]] = m[2];
+    }
+    Object.assign(env, envUpdates);
+    const newContent = Object.entries(env).map(([k,v]) => `${k}=${v}`).join('\n');
+    fs.writeFileSync(file, newContent);
+    console.log(`Mis a jour: ${file}`);
+  }
+})();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
       "target": "ES2020",
-      "typeRoots": ["node_modules/@types", "src"],
       "module": "commonjs",
       "strict": true,
       "esModuleInterop": true,


### PR DESCRIPTION
## Summary
- allow specifying data folder through `setup-env.js`
- reference new env vars in README
- update scripts and backend to load custom paths
- generate updated build output

## Testing
- `npm --workspace backend run build`

------
https://chatgpt.com/codex/tasks/task_e_6852de3b46948323aa630d3d0ffe21a3