### PR TITLE
Fix backend env loading

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,12 +1,15 @@
 import path from 'path';
+import fs from 'fs';
 import dotenv from 'dotenv';
 
-// Charger **immédiatement** le .env du dossier backend
-dotenv.config({ path: path.resolve(__dirname, '../.env') });
+// Charger le .env racine puis celui du backend (ce dernier a priorité)
+const ROOT_ENV = path.resolve(__dirname, '../..', '.env');
+const BACK_ENV = path.resolve(__dirname, '../.env');
+if (fs.existsSync(ROOT_ENV)) dotenv.config({ path: ROOT_ENV });
+if (fs.existsSync(BACK_ENV)) dotenv.config({ path: BACK_ENV, override: true });
 
 import express from 'express';
 import cors from 'cors';
-import fs from 'fs';
 
 import authRouter from './routes/auth';
 import usersRouter from './routes/users';

--- a/backend/src/utils/analytics.ts
+++ b/backend/src/utils/analytics.ts
@@ -3,7 +3,10 @@ import path from 'path';
 import { Request } from 'express';
 import { IAnalytics, SessionRecord, FavoriteRecord, Role } from '../models/IAnalytics';
 
-const DATA_FILE = path.resolve(__dirname, '../data/analytics.json');
+const DATA_DIR = process.env.DATA_DIR
+  ? path.resolve(process.env.DATA_DIR)
+  : path.resolve(__dirname, '..', 'data');
+const DATA_FILE = path.join(DATA_DIR, 'analytics.json');
 
 function load(): IAnalytics {
   if (!fs.existsSync(DATA_FILE)) {
@@ -125,10 +128,10 @@ export function computeAnalytics(): AnalyticsSummary {
   let users: any[] = [];
   let modules: any[] = [];
   try {
-    users = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../data/users.json'), 'utf8'));
+    users = JSON.parse(fs.readFileSync(path.join(DATA_DIR, 'users.json'), 'utf8'));
   } catch {}
   try {
-    modules = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../data/modules.json'), 'utf8'));
+    modules = JSON.parse(fs.readFileSync(path.join(DATA_DIR, 'modules.json'), 'utf8'));
   } catch {}
 
   const userRoles: Record<string,string> = {};
@@ -192,7 +195,7 @@ export function computeAnalytics(): AnalyticsSummary {
   let favLists: any[] = [];
   try {
     favLists = JSON.parse(
-      fs.readFileSync(path.resolve(__dirname, '../data/favorites.json'), 'utf8'),
+      fs.readFileSync(path.join(DATA_DIR, 'favorites.json'), 'utf8'),
     );
   } catch {}
   favLists.forEach(f => {

--- a/scripts/env.js
+++ b/scripts/env.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+const dotenv = require('dotenv');
+
+const ROOT = path.resolve(__dirname, '..');
+const BACKEND = path.join(ROOT, 'backend');
+
+function load() {
+  const rootEnv = path.join(ROOT, '.env');
+  const backEnv = path.join(BACKEND, '.env');
+  if (fs.existsSync(rootEnv)) dotenv.config({ path: rootEnv });
+  if (fs.existsSync(backEnv)) dotenv.config({ path: backEnv, override: true });
+}
+
+function normalize(p) {
+  return p.split(/[\\/]+/).join(path.sep);
+}
+
+function resolveDir(envVar, fallback) {
+  const value = process.env[envVar];
+  if (value) {
+    const norm = normalize(value);
+    return path.isAbsolute(value)
+      ? path.resolve(norm)
+      : path.resolve(BACKEND, norm);
+  }
+  return path.resolve(BACKEND, fallback);
+}
+
+module.exports = { load, resolveDir, ROOT, BACKEND };

--- a/scripts/fixSessions.js
+++ b/scripts/fixSessions.js
@@ -1,12 +1,14 @@
 const fs = require('fs');
 const path = require('path');
+const { load, resolveDir } = require('./env');
 
-const DATA_DIR = process.env.DATA_DIR
-  ? path.resolve(process.env.DATA_DIR)
-  : path.join(__dirname, '../backend/src/data');
+// Charge les variables d'environnement (.env racine puis backend)
+load();
+
+const DATA_DIR = resolveDir('DATA_DIR', 'src/data');
 const FILE = path.join(DATA_DIR, 'analytics.json');
 
-function load() {
+function loadFile() {
   try {
     return JSON.parse(fs.readFileSync(FILE, 'utf8'));
   } catch {
@@ -14,12 +16,12 @@ function load() {
   }
 }
 
-function save(data) {
+function saveFile(data) {
   fs.writeFileSync(FILE, JSON.stringify(data, null, 2));
 }
 
 function addMissingLogouts() {
-  const data = load();
+  const data = loadFile();
   if (!Array.isArray(data.sessions)) return;
 
   let changed = false;
@@ -41,7 +43,7 @@ function addMissingLogouts() {
   });
 
   if (changed) {
-    save(data);
+    saveFile(data);
     console.log('Analytics updated.');
   } else {
     console.log('No missing logouts found.');

--- a/scripts/rgpdCleanup.js
+++ b/scripts/rgpdCleanup.js
@@ -1,13 +1,13 @@
 
 const fs = require('fs');
 const path = require('path');
+const { load, resolveDir } = require('./env');
 
-const DATA_DIR = process.env.DATA_DIR
-  ? path.resolve(process.env.DATA_DIR)
-  : path.join(__dirname, '../backend/src/data');
-const ARCHIVE_DIR = process.env.ARCHIVE_DIR
-  ? path.resolve(process.env.ARCHIVE_DIR)
-  : path.join(__dirname, '../backend/archive');
+// Charge les variables d'environnement (.env racine puis backend)
+load();
+
+const DATA_DIR = resolveDir('DATA_DIR', 'src/data');
+const ARCHIVE_DIR = resolveDir('ARCHIVE_DIR', 'archive');
 
 if (!fs.existsSync(ARCHIVE_DIR)) fs.mkdirSync(ARCHIVE_DIR, { recursive: true });
 


### PR DESCRIPTION
## Summary
- load root `.env` before backend env in server startup
- respect `DATA_DIR` for analytics JSON file

## Testing
- `node scripts/rgpdCleanup.js`
- `node scripts/fixSessions.js`
- `npm --workspace backend run --silent build`


------
https://chatgpt.com/codex/tasks/task_e_6854245ebfb88323b082fd9e6293a3a7