### PR TITLE
Fix logout beacon on tab close

### DIFF
--- a/client/src/context/AuthContext.tsx
+++ b/client/src/context/AuthContext.tsx
@@ -58,7 +58,6 @@ import React, {
         useEffect(() => {
           let reloading = false;
           let hideTime = 0;
-          let timer: number | undefined;
 
           const markReload = (e: KeyboardEvent) => {
             const key = e.key.toLowerCase();
@@ -79,28 +78,24 @@ import React, {
           const handleVisibility = () => {
             if (document.visibilityState === 'hidden') {
               hideTime = Date.now();
-              timer = window.setTimeout(sendLogout, 300);
-            } else {
-              if (hideTime && Date.now() - hideTime < 500) {
-                reloading = true;
-              }
-              hideTime = 0;
-              if (timer) {
-                clearTimeout(timer);
-                timer = undefined;
-              }
             }
+          };
+
+          const handlePageHide = () => {
+            if (hideTime && Date.now() - hideTime < 500) {
+              reloading = true;
+            }
+            sendLogout();
           };
 
           window.addEventListener('keydown', markReload);
           document.addEventListener('visibilitychange', handleVisibility);
-          window.addEventListener('pagehide', handleVisibility);
+          window.addEventListener('pagehide', handlePageHide);
 
           return () => {
             window.removeEventListener('keydown', markReload);
             document.removeEventListener('visibilitychange', handleVisibility);
-            window.removeEventListener('pagehide', handleVisibility);
-            if (timer) clearTimeout(timer);
+            window.removeEventListener('pagehide', handlePageHide);
           };
         }, [user]);
     


### PR DESCRIPTION
## Summary
- fix automatic logout recording when closing the tab

## Testing
- `npm --workspace client test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685520b308ec832381121395204e5bfb